### PR TITLE
refactor: unify logging across core modules

### DIFF
--- a/mlox/cli.py
+++ b/mlox/cli.py
@@ -3,6 +3,7 @@ import sys
 import typer
 import shutil
 import subprocess
+import logging
 
 from importlib import resources
 
@@ -11,14 +12,21 @@ from mlox.infra import Infrastructure
 from mlox.config import load_config, get_stacks_path
 
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)s] %(asctime)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
 app = typer.Typer(no_args_is_help=True)
 
 infra_app = typer.Typer(no_args_is_help=True)
 
 
 def setup_demo_project(ip1: str, ip2: str, ip3: str):
-    print("[MLOX DEMO] Setting up demo project with provided IPs...")
-    print(f"Using IPs: {ip1}, {ip2}, {ip3}")
+    logger.info("[MLOX DEMO] Setting up demo project with provided IPs...")
+    logger.info(f"Using IPs: {ip1}, {ip2}, {ip3}")
     infra = Infrastructure()
     config_native = load_config(
         get_stacks_path(), "/ubuntu", "mlox-server.ubuntu.native.yaml"
@@ -30,7 +38,7 @@ def setup_demo_project(ip1: str, ip2: str, ip3: str):
         get_stacks_path(), "/ubuntu", "mlox-server.ubuntu.k3s.yaml"
     )
     if not config_native or not config_docker or not config_k8s:
-        print("[MLOX DEMO] One or more configurations not found. Exiting setup.")
+        logger.error("[MLOX DEMO] One or more configurations not found. Exiting setup.")
         return
     params = dict()
     params["${MLOX_IP}"] = ip1
@@ -45,7 +53,7 @@ def setup_demo_project(ip1: str, ip2: str, ip3: str):
         password="demo",
     )
     if ms is None:
-        print("[MLOX DEMO] Failed to create MloxSession. Exiting setup.")
+        logger.error("[MLOX DEMO] Failed to create MloxSession. Exiting setup.")
         return
     params["${MLOX_IP}"] = ip2
     ms.infra.add_server(config=config_docker, params=params)
@@ -67,25 +75,25 @@ def demo():
         with resources.as_file(
             resources.files("mlox.assets").joinpath("start-multipass-testbed.sh")
         ) as script_path:
-            print(f"[MLOX DEMO] Executing multipass testbed script: {script_path}")
+            logger.info(f"[MLOX DEMO] Executing multipass testbed script: {script_path}")
             os.chmod(script_path, 0o755)
             subprocess.run([str(script_path)], check=True)
     except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        print(f"[MLOX DEMO] Error starting multipass testbed: {e}", file=sys.stderr)
+        logger.error(f"[MLOX DEMO] Error starting multipass testbed: {e}")
         sys.exit(1)
 
     # 2. Wait a moment for VMs to boot
-    print("[MLOX DEMO] Waiting for VMs to boot...")
+    logger.info("[MLOX DEMO] Waiting for VMs to boot...")
     time.sleep(5)
 
     # 3. Print multipass list (show IPs) and extract demo instance IPs
     ip_map = {}
     try:
-        print("[MLOX DEMO] Listing multipass VMs:")
+        logger.info("[MLOX DEMO] Listing multipass VMs:")
         result = subprocess.run(
             ["multipass", "list"], check=True, capture_output=True, text=True
         )
-        print(result.stdout)
+        logger.info(result.stdout)
         for line in result.stdout.splitlines():
             parts = line.split()
             if len(parts) >= 4 and parts[0] in {
@@ -96,24 +104,24 @@ def demo():
                 # The IPv4 is always the 3rd column
                 ip_map[parts[0]] = parts[2]
     except Exception as e:
-        print(f"[MLOX DEMO] Could not list multipass VMs: {e}", file=sys.stderr)
+        logger.error(f"[MLOX DEMO] Could not list multipass VMs: {e}")
 
     # 4. Print default user/pw (hardcoded or documented)
-    print("[MLOX DEMO] Default credentials for testbed VMs:")
-    print("  username: root")
-    print("  password: pass")
+    logger.info("[MLOX DEMO] Default credentials for testbed VMs:")
+    logger.info("  username: root")
+    logger.info("  password: pass")
 
     # 5. Start the UI
-    print("[MLOX DEMO] Setup project DEMO...")
+    logger.info("[MLOX DEMO] Setup project DEMO...")
 
     # Use the extracted IPs for setup_demo_project
     ip1 = ip_map.get("mlox-demo-1", "")
     ip2 = ip_map.get("mlox-demo-2", "")
     ip3 = ip_map.get("mlox-demo-3", "")
     setup_demo_project(ip1, ip2, ip3)
-    print("[MLOX DEMO] Launching MLOX UI...")
+    logger.info("[MLOX DEMO] Launching MLOX UI...")
     start_ui({"MLOX_PROJECT": "demo", "MLOX_PASSWORD": "demo"})
-    print("End of demo setup.")
+    logger.info("End of demo setup.")
 
 
 def start_multipass():
@@ -125,13 +133,13 @@ def start_multipass():
         with resources.as_file(
             resources.files("mlox.assets").joinpath("start-multipass.sh")
         ) as script_path:
-            print(f"Executing multipass startup script from: {script_path}")
+            logger.info(f"Executing multipass startup script from: {script_path}")
             # Make sure the script is executable
             os.chmod(script_path, 0o755)
             # Run the script
             subprocess.run([str(script_path)], check=True)
     except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        print(f"Error starting multipass: {e}", file=sys.stderr)
+        logger.error(f"Error starting multipass: {e}")
         sys.exit(1)
 
 
@@ -152,15 +160,14 @@ def start_ui(env: dict | None = None):
             os.makedirs(dest_dir, exist_ok=True)
             with resources.as_file(source_config_path_obj) as source_path:
                 shutil.copy(source_path, dest_config_path)
-                print(f"Copied theme config to {dest_config_path}")
+                logger.info(f"Copied theme config to {dest_config_path}")
         except Exception as e:
-            print(
-                f"Warning: Could not copy theme configuration. UI will use default theme. Error: {e}",
-                file=sys.stderr,
+            logger.warning(
+                f"Warning: Could not copy theme configuration. UI will use default theme. Error: {e}"
             )
 
         app_path = str(resources.files("mlox").joinpath("app.py"))
-        print(f"Launching MLOX UI from: {app_path}")
+        logger.info(f"Launching MLOX UI from: {app_path}")
         # Prepare environment variables
         run_env = os.environ.copy()
         if env:
@@ -171,7 +178,7 @@ def start_ui(env: dict | None = None):
             env=run_env,
         )
     except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        print(f"Error starting Streamlit UI: {e}", file=sys.stderr)
+        logger.error(f"Error starting Streamlit UI: {e}")
         sys.exit(1)
 
 

--- a/mlox/remote.py
+++ b/mlox/remote.py
@@ -9,6 +9,11 @@ from io import BytesIO
 from typing import Dict, Tuple
 from fabric import Connection, Config  # type: ignore
 
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)s] %(asctime)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
 logger = logging.getLogger(__name__)
 
 
@@ -56,17 +61,16 @@ def close_connection(conn, tmp_dir=None):
 
 
 def exec_command(conn, cmd, sudo=False, pty=False):
-    print(f"Execute CMD: {cmd}")
+    logger.debug(f"Executing command: {cmd}")
     res = None
     hide = "stderr" if sudo else True
     if sudo:
         try:
             res = conn.sudo(cmd, hide=hide, pty=pty).stdout.strip()
         except Exception as e:
-            print(e)
+            logger.error(f"Command failed: {e}")
     else:
         res = conn.run(cmd, hide=hide).stdout.strip()
-    # print(res)
     return res
 
 

--- a/mlox/remote.py
+++ b/mlox/remote.py
@@ -127,7 +127,7 @@ def sys_add_user(
 def docker_list_container(conn):
     res = exec_command(conn, "docker container ls", sudo=True)
     dl = str(res).split("\n")
-    dlist = [re.sub("\ {2,}", "    ", dl[i]).split("   ") for i in range(len(dl))]
+    dlist = [re.sub(r"\ {2,}", "    ", dl[i]).split("   ") for i in range(len(dl))]
     return dlist
 
 

--- a/mlox/server.py
+++ b/mlox/server.py
@@ -20,9 +20,10 @@ import socket
 from mlox.utils import generate_password
 from mlox.remote import open_connection, close_connection, exec_command, fs_read_file
 
-# Configure logging (optional, but recommended)
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    level=logging.INFO,
+    format="[%(levelname)s] %(asctime)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
 
@@ -250,9 +251,9 @@ class AbstractServer(ABC):
             with self.get_server_connection() as conn:
                 if conn.is_connected:
                     verified = True
-            print(f"Public key SSH login verified={verified}.")
+            logger.info(f"Public key SSH login verified={verified}.")
         except Exception as e:
-            print(f"Failed to login via SSH with public key: {e}")
+            logger.error(f"Failed to login via SSH with public key: {e}")
         return verified
 
     @abstractmethod
@@ -383,7 +384,7 @@ def execute_command(conn, cmd: List | str):
             module = importlib.import_module(module_name)
             func = getattr(module, func_name)
             args = cmd[1:]
-            print(f"Execute CMD: {func_name} with args: {args}")
+            logger.debug(f"Execute CMD: {func_name} with args: {args}")
             if args:
                 func(conn, *args)
             else:


### PR DESCRIPTION
## Summary
- replace print statements with logging calls in remote, server, and CLI modules
- apply consistent logging configuration and per-module loggers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'psycopg2')*
- `flake8` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2378581083228c057eb288ccf5d6