### PR TITLE
Add integration test for MLflow service

### DIFF
--- a/tests/integration/test_service_mlflow.py
+++ b/tests/integration/test_service_mlflow.py
@@ -1,0 +1,58 @@
+import time
+import pytest
+
+from mlox.config import load_config, get_stacks_path
+from mlox.infra import Infrastructure, Bundle
+
+# Mark this module as an integration test
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def install_mlflow_service(ubuntu_docker_server):
+    """Install and start the MLflow service on the provided server."""
+    # Prepare infrastructure with the existing server
+    infra = Infrastructure()
+    bundle = Bundle(name=ubuntu_docker_server.ip, server=ubuntu_docker_server)
+    infra.bundles.append(bundle)
+
+    # Load MLflow service configuration
+    config = load_config(get_stacks_path(), "/mlflow", "mlox.mlflow.2.22.0.yaml")
+
+    bundle_added = infra.add_service(ubuntu_docker_server.ip, config, params={})
+    if not bundle_added:
+        pytest.skip("Failed to add MLflow service from config")
+
+    service = bundle_added.services[-1]
+
+    # Setup and start the service
+    with ubuntu_docker_server.get_server_connection() as conn:
+        service.setup(conn)
+        service.spin_up(conn)
+        # Allow some time for containers to become healthy
+        time.sleep(10)
+
+    yield bundle_added, service
+
+    # Teardown after tests
+    with ubuntu_docker_server.get_server_connection() as conn:
+        try:
+            service.spin_down(conn)
+        except Exception:
+            pass
+        try:
+            service.teardown(conn)
+        except Exception:
+            pass
+    infra.remove_bundle(bundle_added)
+
+
+def test_mlflow_service_is_running(install_mlflow_service):
+    """Verify MLflow service is reported as running and exposes a URL."""
+    bundle, service = install_mlflow_service
+    assert service.service_url
+    assert service.state == "running"
+
+    with bundle.server.get_server_connection() as conn:
+        status = service.check(conn)
+    assert status.get("status") == "running"


### PR DESCRIPTION
## Summary
- add integration test validating MLflow service deployment via `ubuntu_docker_server`

## Testing
- `pytest tests/integration/test_service_mlflow.py::test_mlflow_service_is_running -q` *(fails: ModuleNotFoundError: No module named 'multipass')*
- `pip install multipass` *(fails: Could not find a version that satisfies the requirement multipass)*

------
https://chatgpt.com/codex/tasks/task_e_68aed44024308322a3100be2c322af19