### PR TITLE
feat(ui): add Textual terminal interface

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 122

--- a/mlox/cli.py
+++ b/mlox/cli.py
@@ -182,6 +182,28 @@ def start_ui(env: dict | None = None):
         sys.exit(1)
 
 
+def start_tui(env: dict | None = None):
+    """Launch the Textual-based terminal UI."""
+    try:
+        try:
+            import textual  # noqa: F401
+        except Exception:
+            logger.error(
+                "Textual is not installed. Please install 'textual' to use the terminal UI."
+            )
+            sys.exit(1)
+
+        app_path = str(resources.files("mlox").joinpath("tui.py"))
+        logger.info(f"Launching MLOX TUI from: {app_path}")
+        run_env = os.environ.copy()
+        if env:
+            run_env.update(env)
+        subprocess.run([sys.executable, app_path], check=True, env=run_env)
+    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+        logger.error(f"Error starting Textual UI: {e}")
+        sys.exit(1)
+
+
 def get_session(project: str, password: str) -> MloxSession:
     try:
         session = MloxSession(project, password)
@@ -218,6 +240,23 @@ def ui(
         env["MLOX_PASSWORD"] = password
     # Optionally, you could pass session to the UI if needed
     start_ui(env)
+
+
+@app.command()
+def tui(
+    project: str = typer.Option(
+        "", prompt_required=False, help="Project name (username for session)"
+    ),
+    password: str = typer.Option(
+        "", prompt_required=False, hide_input=True, help="Password for the session"
+    ),
+):
+    """Start the MLOX terminal UI (requires project and password)"""
+    env: dict = {}
+    if len(password) > 4 and len(project) >= 1:
+        env["MLOX_PROJECT"] = project
+        env["MLOX_PASSWORD"] = password
+    start_tui(env)
 
 
 @infra_app.command("list")

--- a/mlox/logging_config.py
+++ b/mlox/logging_config.py
@@ -5,6 +5,8 @@ import logging.config
 
 from typing import Optional
 
+from textual.logging import TextualHandler
+
 # Try to use colorama on platforms that need it (optional dependency)
 try:
     import colorama  # type: ignore
@@ -68,9 +70,38 @@ LOG_CONFIG = {
     "root": {"handlers": ["console"], "level": "INFO"},
 }
 
+LOG_CONFIG_TEXTUAL = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    # "formatters": {
+    #     "colored": {
+    #         "()": ColoredFormatter,
+    #         "fmt": LOG_FORMAT,
+    #         "datefmt": DATE_FMT,
+    #         "use_color": True,
+    #     },
+    # },
+    "handlers": {
+        "console_tui": {
+            "class": TextualHandler,
+            # "formatter": "colored",
+            # "level": "INFO",
+            "stream": "ext://sys.stdout",
+        }
+    },
+    "root": {"handlers": ["console_tui"], "level": "INFO"},
+}
+
 
 def configure_logging() -> None:
     """Configure logging for the project. Call once at startup.
     Set NO_COLOR=1 to disable colors, or install colorama for Windows support.
     """
-    logging.config.dictConfig(LOG_CONFIG)
+    if os.environ.get("MLOX_TUI") == "true":
+        logging.basicConfig(
+            handlers=[TextualHandler(stderr=True, stdout=True)], level=logging.INFO
+        )
+        logging.info("Textual logging configured")
+    else:
+        logging.config.dictConfig(LOG_CONFIG)
+        logging.info("Logging configured")

--- a/mlox/services/otel/client.py
+++ b/mlox/services/otel/client.py
@@ -1,5 +1,4 @@
 import grpc  # type: ignore
-import time
 import logging
 
 from typing import Dict, Any, Optional

--- a/mlox/tui.py
+++ b/mlox/tui.py
@@ -1,0 +1,120 @@
+"""Textual-based alternative UI for MLOX.
+
+This module provides a simple terminal user interface using the
+`textual` framework as an alternative to the Streamlit UI.  It offers a
+basic login screen and a minimal set of pages that demonstrate how the
+terminal UI could look.  The functionality is intentionally limited but
+serves as a starting point for further development.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    Input,
+    Static,
+    TabPane,
+    TabbedContent,
+)
+
+from mlox.session import MloxSession
+
+
+WELCOME_TEXT = """\
+Accelerate your ML journey—deploy production-ready MLOps in minutes, not months.
+
+MLOX helps individuals and small teams deploy, configure, and monitor full
+MLOps stacks with minimal effort.
+"""
+
+
+class LoginScreen(Screen):
+    """Simple login screen that collects project and password."""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with Container(id="login-form"):
+            yield Static("MLOX Login", id="login-title")
+            yield Input(placeholder="Project", id="project")
+            yield Input(placeholder="Password", password=True, id="password")
+            yield Button("Login", id="login-btn")
+            yield Static("", id="message")
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:  # pragma: no cover - UI callback
+        if event.button.id != "login-btn":
+            return
+        project = self.query_one("#project", Input).value
+        password = self.query_one("#password", Input).value
+        if self.app.login(project, password):
+            self.app.switch_screen("main")
+        else:
+            self.query_one("#message", Static).update("Login failed")
+
+
+class MainScreen(Screen):
+    """Main application screen shown after login."""
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield TabbedContent(
+            TabPane("Home", Static(WELCOME_TEXT)),
+            TabPane("Infrastructure", Static("Infrastructure view coming soon.")),
+            TabPane("Services", Static("Services view coming soon.")),
+        )
+        yield Footer()
+
+
+class MLOXTextualApp(App):
+    """Main Textual application."""
+
+    CSS_PATH = None
+    BINDINGS = [("q", "quit", "Quit")]
+    SCREENS = {
+        "login": LoginScreen(),
+        "main": MainScreen(),
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.session: Optional[MloxSession] = None
+
+    def login(self, project: str, password: str) -> bool:
+        try:
+            ms = MloxSession(project, password)
+            if ms.secrets.is_working():
+                self.session = ms
+                return True
+        except Exception:
+            pass
+        return False
+
+    def auto_login(self) -> bool:
+        prj = os.environ.get("MLOX_PROJECT")
+        pw = os.environ.get("MLOX_PASSWORD")
+        if prj and pw:
+            return self.login(prj, pw)
+        return False
+
+    def on_mount(self) -> None:  # pragma: no cover - UI lifecycle
+        if self.auto_login():
+            self.push_screen("main")
+        else:
+            self.push_screen("login")
+
+
+def main() -> None:  # pragma: no cover - entry point
+    MLOXTextualApp().run()
+
+
+if __name__ == "__main__":  # pragma: no cover - script execution
+    main()
+

--- a/mlox/tui.py
+++ b/mlox/tui.py
@@ -43,19 +43,33 @@ class LoginScreen(Screen):
         yield Header(show_clock=True)
         with Container(id="login-form"):
             yield Static("MLOX Login", id="login-title")
-            yield Input(placeholder="Project", id="project")
-            yield Input(placeholder="Password", password=True, id="password")
+            yield Input(
+                value=os.environ.get("MLOX_CONFIG_USER", "mlox"),
+                placeholder="Project",
+                id="project",
+            )
+            yield Input(
+                value=os.environ.get("MLOX_CONFIG_PASSWORD", ""),
+                placeholder="Password",
+                password=True,
+                id="password",
+            )
             yield Button("Login", id="login-btn")
             yield Static("", id="message")
         yield Footer()
 
-    def on_button_pressed(self, event: Button.Pressed) -> None:  # pragma: no cover - UI callback
+    def on_button_pressed(
+        self, event: Button.Pressed
+    ) -> None:  # pragma: no cover - UI callback
         if event.button.id != "login-btn":
             return
         project = self.query_one("#project", Input).value
         password = self.query_one("#password", Input).value
-        if self.app.login(project, password):
-            self.app.switch_screen("main")
+        # Call the app's login method if available, then navigate to main screen
+        login_fn = getattr(self.app, "login", None)
+        if callable(login_fn) and login_fn(project, password):
+            # Use push_screen for broader Textual compatibility
+            self.app.push_screen("main")
         else:
             self.query_one("#message", Static).update("Login failed")
 
@@ -117,4 +131,3 @@ def main() -> None:  # pragma: no cover - entry point
 
 if __name__ == "__main__":  # pragma: no cover - script execution
     main()
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ all = [
     # UI and data
     "streamlit==1.49.1",  # M
     "streamlit-vis-timeline==0.3.0",  # M
+    "textual==0.78.1",  # M
     "backports.tarfile>=1.0",
     "pandas>=2.2",
     "numpy>=1.26",
@@ -95,6 +96,7 @@ dev = [
     # developer extras (includes 'all')
     "streamlit==1.49.1",  # M
     "streamlit-vis-timeline==0.3.0",  # M
+    "textual==0.78.1",  # M
     "backports.tarfile>=1.0",
     "pandas>=2.2",
     "numpy>=1.26",

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ streamlit-vis-timeline>=0.0.6
 pandas>=2.2
 numpy>=1.26
 psutil>=5.9
+textual>=0.78
 
 ######################## SERVICES
 mlflow>=2.5

--- a/taskfile.dist.yml
+++ b/taskfile.dist.yml
@@ -224,3 +224,46 @@ tasks:
       - multipass list | grep {{.PREFIX}} | cut -d' ' -f1 | xargs multipass delete $1 --purge
       - printf '\n\033[1;32m══════════ ✓ AFTER CLEANUP (Multipass VMs) ✓ ══════════\033[0m\n'; multipass list || true
     desc: Remove all Multipass VMs starting with the given prefix
+
+  # -----------------------
+  # UI helpers (local dev)
+  # -----------------------
+  ui:streamlit:
+    desc: Start the Streamlit UI (local)
+    cmds:
+      - |
+        if ! {{.PYTHON | default "python"}} -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('streamlit') else 1)"; then \
+          printf '\n\033[1;31m✖ streamlit is not installed.\033[0m\n'; \
+          printf 'Install dev deps first, e.g.: \033[1m{{.PYTHON | default "python"}} -m pip install -e .[dev]\033[0m\n\n'; \
+          exit 1; \
+        fi
+      - "streamlit run mlox/app.py"
+
+  ui:cli:
+    desc: Start the Typer CLI app
+    cmds:
+      - '{{.PYTHON | default "python"}} -m mlox.cli'
+
+  ui:textual:terminal:
+    desc: Start the Textual TUI in the terminal
+    cmds:
+      - |
+        if ! {{.PYTHON | default "python"}} -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('textual') else 1)"; then \
+          printf '\n\033[1;31m✖ textual is not installed.\033[0m\n'; \
+          printf 'Install dev deps first, e.g.: \033[1m{{.PYTHON | default "python"}} -m pip install -e .[dev]\033[0m\n\n'; \
+          exit 1; \
+        fi
+      - "export MLOX_TUI=true; textual run --dev mlox/tui.py"
+
+  ui:textual:web:
+    desc: Serve the Textual TUI over the web (dev server)
+    env:
+      MLOX_TUI: "true"
+    cmds:
+      - |
+        if ! {{.PYTHON | default "python"}} -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('textual') else 1)"; then \
+          printf '\n\033[1;31m✖ textual is not installed.\033[0m\n'; \
+          printf 'Install dev deps first, e.g.: \033[1m{{.PYTHON | default "python"}} -m pip install -e .[dev]\033[0m\n\n'; \
+          exit 1; \
+        fi
+      - "export MLOX_TUI=true; textual serve --dev mlox/tui.py"

--- a/taskfile.dist.yml
+++ b/taskfile.dist.yml
@@ -47,7 +47,7 @@ tasks:
           printf 'Install dev deps first, e.g.: \033[1m{{.PYTHON | default "python"}} -m pip install -e .[dev]\033[0m\n\n'; \
           exit 1; \
         fi
-      - '{{.PYTHON | default "python"}} -m flake8 mlox tests --max-line-length=128 --statistics --extend-ignore=E203,W503'
+      - '{{.PYTHON | default "python"}} -m flake8 mlox tests --statistics --extend-ignore=E203,W503'
 
   dev:env:create:
     desc: Create a Conda dev environment with selected Python and install .[dev]
@@ -82,8 +82,8 @@ tasks:
     cmds:
       - task: dev:env:create
         vars:
-          NAME: '{{.NAME}}'
-          PY: '{{.PY}}'
+          NAME: "{{.NAME}}"
+          PY: "{{.PY}}"
       - |
         printf '\n\033[1;35m══════════════════════════════════════════════════════════\033[0m\n'
         printf '\033[1;35m   ✅ Next Steps\033[0m\n'


### PR DESCRIPTION
## Summary
- add initial Textual-based terminal user interface
- expose new `tui` command in CLI to launch terminal UI
- include `textual` dependency in project configs

## Testing
- `pytest` *(fails: No module named 'multipass'; No module named 'mlox')*

------
https://chatgpt.com/codex/tasks/task_e_68bca2f19ce48322b3fa95fc87fee626