### PR TITLE
Add InfluxDB integration tests and docker status check

### DIFF
--- a/mlox/services/influx/docker.py
+++ b/mlox/services/influx/docker.py
@@ -12,6 +12,7 @@ from mlox.remote import (
     docker_down,
     fs_delete_dir,
     exec_command,
+    docker_service_state,
 )
 
 
@@ -67,4 +68,11 @@ class InfluxDockerService(AbstractService):
         fs_delete_dir(conn, self.target_path)
 
     def check(self, conn) -> Dict:
+        try:
+            state = docker_service_state(conn, "influxdbv2")
+            self.state = state if state else "unknown"
+            return {"status": self.state}
+        except Exception as e:
+            logging.error(f"Error checking InfluxDB service status: {e}")
+            self.state = "unknown"
         return {"status": "unknown"}

--- a/mlox/services/influx/docker.py
+++ b/mlox/services/influx/docker.py
@@ -70,8 +70,7 @@ class InfluxDockerService(AbstractService):
     def check(self, conn) -> Dict:
         try:
             state = docker_service_state(conn, "influxdbv2")
-            self.state = state if state else "unknown"
-            return {"status": self.state}
+            return {"status": state}
         except Exception as e:
             logging.error(f"Error checking InfluxDB service status: {e}")
             self.state = "unknown"

--- a/tests/integration/test_service_influx.py
+++ b/tests/integration/test_service_influx.py
@@ -1,0 +1,88 @@
+import logging
+import pytest
+from influxdb import InfluxDBClient
+
+from mlox.config import load_config, get_stacks_path
+from mlox.infra import Infrastructure, Bundle
+
+from tests.integration.conftest import wait_for_service_ready
+
+
+pytestmark = pytest.mark.integration
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def install_influx_service(ubuntu_docker_server):
+    """Install and start the InfluxDB service on the provided server."""
+    infra = Infrastructure()
+    bundle = Bundle(name=ubuntu_docker_server.ip, server=ubuntu_docker_server)
+    infra.bundles.append(bundle)
+
+    config = load_config(get_stacks_path(), "/influx", "mlox.influx.1.11.8.yaml")
+
+    bundle_added = infra.add_service(ubuntu_docker_server.ip, config, params={})
+    if not bundle_added:
+        pytest.skip("Failed to add InfluxDB service from config")
+
+    service = bundle_added.services[-1]
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        service.setup(conn)
+        service.spin_up(conn)
+
+    wait_for_service_ready(service, bundle, retries=6, interval=30, no_checks=True)
+
+    yield bundle_added, service
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        try:
+            service.spin_down(conn)
+        except Exception as e:
+            logger.warning(f"Ignoring error during service spin_down for teardown: {e}")
+        try:
+            service.teardown(conn)
+        except Exception as e:
+            logger.warning(f"Ignoring error during service teardown: {e}")
+    infra.remove_bundle(bundle_added)
+
+
+def test_influx_service_is_running(install_influx_service):
+    bundle, service = install_influx_service
+    wait_for_service_ready(service, bundle, retries=60, interval=10)
+
+    status = {}
+    try:
+        with bundle.server.get_server_connection() as conn:
+            status = service.check(conn)
+    except Exception as e:
+        logger.error(f"Error checking InfluxDB service status: {e}")
+
+    assert status.get("status", None) == "running"
+
+
+def test_influxdb_write_and_read(install_influx_service):
+    bundle, service = install_influx_service
+    wait_for_service_ready(service, bundle, retries=60, interval=10)
+
+    host = bundle.server.ip
+    port = service.port
+    user = service.user
+    password = service.pw
+    dbname = "test_integration_db"
+
+    client = InfluxDBClient(host, port, user, password, dbname, ssl=True, verify_ssl=False)
+    client.create_database(dbname)
+
+    json_body = [
+        {
+            "measurement": "cpu_load_short",
+            "tags": {"host": "server01", "region": "us-west"},
+            "fields": {"Float_value": 0.64},
+        }
+    ]
+    client.write_points(json_body)
+
+    result = list(client.query("select * from cpu_load_short").get_points())
+    assert result, "Expected at least one data point from InfluxDB"


### PR DESCRIPTION
## Summary
- use remote `docker_service_state` helper when checking InfluxDB container health
- add integration tests that bring up an InfluxDB stack and verify container status and basic read/write

## Testing
- `pytest tests/unit -q` *(fails: No module named 'fabric')*
- `pip install fabric pyyaml` *(fails: Could not find a version that satisfies the requirement fabric)*
- `pytest tests/integration/test_service_influx.py::test_influx_service_is_running -q` *(fails: No module named 'multipass')*

------
https://chatgpt.com/codex/tasks/task_e_68c51f516048832283e863dd76707768