### PR TITLE
Rewrite CLI for project and infrastructure management

### DIFF
--- a/mlox/cli.py
+++ b/mlox/cli.py
@@ -1,17 +1,27 @@
-import os
-import sys
-import time
-import typer
-import shutil
-import subprocess
-import textual  # noqa: F401
-import logging
+"""Command line interface for MLOX.
 
-from importlib import resources
+This rewrite exposes a higher level interface for managing projects,
+servers and services in preparation for a server/client architecture.
+"""
+
+from __future__ import annotations
+
+import os
+import logging
+from typing import Dict, List
+
+import typer
 
 from mlox.session import MloxSession
 from mlox.infra import Infrastructure
-from mlox.config import load_config, get_stacks_path
+from mlox.config import (
+    get_stacks_path,
+    load_config,
+    load_all_service_configs,
+    load_all_server_configs,
+    load_service_config_by_id,
+)
+from mlox.utils import dataclass_to_dict, save_to_json
 
 
 logging.basicConfig(
@@ -21,258 +31,362 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-app = typer.Typer(no_args_is_help=True)
 
-infra_app = typer.Typer(no_args_is_help=True)
+app = typer.Typer(help="MLOX command line interface")
 
+project_app = typer.Typer(help="Manage MLOX projects")
+server_app = typer.Typer(help="Manage servers in the project infrastructure")
+service_app = typer.Typer(help="Manage services running on servers")
+template_app = typer.Typer(help="List available templates")
 
-def setup_demo_project(ip1: str, ip2: str, ip3: str):
-    logger.info("[MLOX DEMO] Setting up demo project with provided IPs...")
-    logger.info(f"Using IPs: {ip1}, {ip2}, {ip3}")
-    infra = Infrastructure()
-    config_native = load_config(
-        get_stacks_path(), "/ubuntu", "mlox-server.ubuntu.native.yaml"
-    )
-    config_docker = load_config(
-        get_stacks_path(), "/ubuntu", "mlox-server.ubuntu.docker.yaml"
-    )
-    config_k8s = load_config(
-        get_stacks_path(), "/ubuntu", "mlox-server.ubuntu.k3s.yaml"
-    )
-    if not config_native or not config_docker or not config_k8s:
-        logger.error("[MLOX DEMO] One or more configurations not found. Exiting setup.")
-        return
-    params = dict()
-    params["${MLOX_IP}"] = ip1
-    params["${MLOX_PORT}"] = "22"
-    params["${MLOX_ROOT}"] = "root"
-    params["${MLOX_ROOT_PW}"] = "pass"
-    ms = MloxSession.new_infrastructure(
-        infra=infra,  # This should be replaced with an actual Infrastructure instance
-        config=config_native,  # This should be replaced with an actual ServerConfig instance
-        params=params,  # This should be replaced with actual parameters for the server
-        username="demo",
-        password="demo",
-    )
-    if ms is None:
-        logger.error("[MLOX DEMO] Failed to create MloxSession. Exiting setup.")
-        return
-    params["${MLOX_IP}"] = ip2
-    ms.infra.add_server(config=config_docker, params=params)
-    params["${MLOX_IP}"] = ip3
-    params["${K3S_CONTROLLER_URL}"] = ""
-    params["${K3S_CONTROLLER_TOKEN}"] = ""
-    params["${K3S_CONTROLLER_UUID}"] = ""
-    ms.infra.add_server(config=config_k8s, params=params)
-    ms.save_infrastructure()
+app.add_typer(project_app, name="project")
+app.add_typer(server_app, name="server")
+app.add_typer(service_app, name="service")
+app.add_typer(template_app, name="templates")
 
 
-@app.command()
-def demo():
-    """Spin up a demo MLOX testbed (3 VMs), show IPs, credentials, and launch the UI."""
-    # 1. Start the multipass testbed
-    try:
-        with resources.as_file(
-            resources.files("mlox.assets").joinpath("start-multipass-testbed.sh")
-        ) as script_path:
-            logger.info(
-                f"[MLOX DEMO] Executing multipass testbed script: {script_path}"
-            )
-            os.chmod(script_path, 0o755)
-            subprocess.run([str(script_path)], check=True)
-    except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        logger.error(f"[MLOX DEMO] Error starting multipass testbed: {e}")
-        sys.exit(1)
-
-    # 2. Wait a moment for VMs to boot
-    logger.info("[MLOX DEMO] Waiting for VMs to boot...")
-    time.sleep(5)
-
-    # 3. Print multipass list (show IPs) and extract demo instance IPs
-    ip_map = {}
-    try:
-        logger.info("[MLOX DEMO] Listing multipass VMs:")
-        result = subprocess.run(
-            ["multipass", "list"], check=True, capture_output=True, text=True
-        )
-        logger.info(result.stdout)
-        for line in result.stdout.splitlines():
-            parts = line.split()
-            if len(parts) >= 4 and parts[0] in {
-                "mlox-demo-1",
-                "mlox-demo-2",
-                "mlox-demo-3",
-            }:
-                # The IPv4 is always the 3rd column
-                ip_map[parts[0]] = parts[2]
-    except Exception as e:
-        logger.error(f"[MLOX DEMO] Could not list multipass VMs: {e}")
-
-    # 4. Print default user/pw (hardcoded or documented)
-    logger.info("[MLOX DEMO] Default credentials for testbed VMs:")
-    logger.info("  username: root")
-    logger.info("  password: pass")
-
-    # 5. Start the UI
-    logger.info("[MLOX DEMO] Setup project DEMO...")
-
-    # Use the extracted IPs for setup_demo_project
-    ip1 = ip_map.get("mlox-demo-1", "")
-    ip2 = ip_map.get("mlox-demo-2", "")
-    ip3 = ip_map.get("mlox-demo-3", "")
-    setup_demo_project(ip1, ip2, ip3)
-    logger.info("[MLOX DEMO] Launching MLOX UI...")
-    start_ui({"MLOX_PROJECT": "demo", "MLOX_PASSWORD": "demo"})
-    logger.info("End of demo setup.")
-
-
-def start_multipass():
-    """
-    Finds and executes the start-multipass.sh script included with the package.
-    """
-    try:
-        # Modern way to access package data files
-        with resources.as_file(
-            resources.files("mlox.assets").joinpath("start-multipass.sh")
-        ) as script_path:
-            logger.info(f"Executing multipass startup script from: {script_path}")
-            # Make sure the script is executable
-            os.chmod(script_path, 0o755)
-            # Run the script
-            subprocess.run([str(script_path)], check=True)
-    except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        logger.error(f"Error starting multipass: {e}")
-        sys.exit(1)
-
-
-def start_ui(env: dict | None = None):
-    """
-    Finds the app.py file within the package and launches it with Streamlit.
-    This replaces the need for a separate start-ui.sh script.
-    Optionally accepts an env dict to pass environment variables to the subprocess.
-    """
-    try:
-        # --- Copy theme config to ensure consistent UI ---
-        try:
-            source_config_path_obj = resources.files("mlox.resources").joinpath(
-                "config.toml"
-            )
-            dest_dir = os.path.join(os.getcwd(), ".streamlit")
-            dest_config_path = os.path.join(dest_dir, "config.toml")
-            os.makedirs(dest_dir, exist_ok=True)
-            with resources.as_file(source_config_path_obj) as source_path:
-                shutil.copy(source_path, dest_config_path)
-                logger.info(f"Copied theme config to {dest_config_path}")
-        except Exception as e:
-            logger.warning(
-                f"Warning: Could not copy theme configuration. UI will use default theme. Error: {e}"
-            )
-
-        app_path = str(resources.files("mlox").joinpath("app.py"))
-        logger.info(f"Launching MLOX UI from: {app_path}")
-        # Prepare environment variables
-        run_env = os.environ.copy()
-        if env:
-            run_env.update(env)
-        subprocess.run(
-            [sys.executable, "-m", "streamlit", "run", app_path],
-            check=True,
-            env=run_env,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        logger.error(f"Error starting Streamlit UI: {e}")
-        sys.exit(1)
-
-
-def start_tui(env: dict | None = None):
-    """Launch the Textual-based terminal UI."""
-    try:
-        app_path = str(resources.files("mlox").joinpath("tui.py"))
-        logger.info(f"Launching MLOX TUI from: {app_path}")
-        run_env = os.environ.copy()
-        if env:
-            run_env.update(env)
-        subprocess.run([sys.executable, app_path], check=True, env=run_env)
-    except (FileNotFoundError, subprocess.CalledProcessError) as e:
-        logger.error(f"Error starting Textual UI: {e}")
-        sys.exit(1)
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def get_session(project: str, password: str) -> MloxSession:
+    """Load an existing :class:`MloxSession` from credentials."""
+
     try:
         session = MloxSession(project, password)
         if not session.secrets.is_working():
             typer.echo(
-                "[ERROR] Could not initialize session (secrets not working)", err=True
+                "[ERROR] Could not initialize session (secrets not working)",
+                err=True,
             )
             raise typer.Exit(code=2)
         return session
-    except Exception as e:
-        typer.echo(f"[ERROR] Failed to load session: {e}", err=True)
+    except Exception as exc:  # pragma: no cover - defensive
+        typer.echo(f"[ERROR] Failed to load session: {exc}", err=True)
         raise typer.Exit(code=1)
 
 
-@app.command()
-def multipass():
-    """Start multipass VM"""
-    start_multipass()
+def parse_kv(pairs: List[str]) -> Dict[str, str]:
+    """Convert a list of ``KEY=VALUE`` strings into a dictionary."""
+
+    data: Dict[str, str] = {}
+    for item in pairs:
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        data[key] = value
+    return data
 
 
-@app.command()
-def ui(
-    project: str = typer.Option(
-        "", prompt_required=False, help="Project name (username for session)"
-    ),
+def _load_config_from_path(path: str):
+    """Load a configuration file relative to the stacks directory."""
+
+    stacks = get_stacks_path()
+    service_dir, candidate = os.path.split(path)
+    return load_config(stacks, service_dir, candidate)
+
+
+# ---------------------------------------------------------------------------
+# Project commands
+# ---------------------------------------------------------------------------
+
+
+@project_app.command("new")
+def project_new(
+    name: str = typer.Argument(..., help="Project name"),
     password: str = typer.Option(
-        "", prompt_required=False, hide_input=True, help="Password for the session"
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    server_template: str = typer.Option(
+        ..., help="Server template path relative to the stacks directory"
+    ),
+    ip: str = typer.Option(..., help="IP or hostname of the server"),
+    port: int = typer.Option(22, help="SSH port of the server"),
+    root_user: str = typer.Option("root", help="Initial root user"),
+    root_pw: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Root password"
+    ),
+    param: List[str] = typer.Option(
+        [], "--param", help="Additional template parameter in the form KEY=VALUE"
     ),
 ):
-    """Start the MLOX UI with Streamlit (requires project and password)"""
-    env: dict = {}
-    if len(password) > 4 and len(project) >= 1:
-        env["MLOX_PROJECT"] = project
-        env["MLOX_PASSWORD"] = password
-    # Optionally, you could pass session to the UI if needed
-    start_ui(env)
+    """Create a new project and initialise the first server."""
+
+    infra = Infrastructure()
+    config = _load_config_from_path(server_template)
+    if not config:
+        typer.echo("[ERROR] Server template not found", err=True)
+        raise typer.Exit(code=1)
+
+    params = {
+        "${MLOX_IP}": ip,
+        "${MLOX_PORT}": str(port),
+        "${MLOX_ROOT}": root_user,
+        "${MLOX_ROOT_PW}": root_pw,
+    }
+    params.update(parse_kv(param))
+
+    ms = MloxSession.new_infrastructure(
+        infra=infra, config=config, params=params, username=name, password=password
+    )
+    if not ms:
+        typer.echo("[ERROR] Failed to initialise project", err=True)
+        raise typer.Exit(code=1)
+    typer.echo(f"Created project '{name}' with server {ip}")
 
 
-@app.command()
-def tui(
-    project: str = typer.Option(
-        "", prompt_required=False, help="Project name (username for session)"
-    ),
-    password: str = typer.Option(
-        "", prompt_required=False, hide_input=True, help="Password for the session"
-    ),
-):
-    """Start the MLOX terminal UI (requires project and password)"""
-    env: dict = {}
-    if len(password) > 4 and len(project) >= 1:
-        env["MLOX_PROJECT"] = project
-        env["MLOX_PASSWORD"] = password
-    start_tui(env)
+# ---------------------------------------------------------------------------
+# Server commands
+# ---------------------------------------------------------------------------
 
 
-@infra_app.command("list")
-def list_bundles(
-    project: str = typer.Option(..., help="Project name (username for session)"),
+@server_app.command("list")
+def server_list(
+    project: str = typer.Argument(..., help="Project name"),
     password: str = typer.Option(
         ..., prompt=True, hide_input=True, help="Password for the session"
     ),
 ):
-    """List bundle names of the loaded infrastructure for the given project and password."""
+    """List all servers registered in the project infrastructure."""
+
     session = get_session(project, password)
     if not session.infra.bundles:
-        typer.echo("No bundles found.")
-        raise typer.Exit(code=3)
-    typer.echo("Loaded bundles:")
-    for b in session.infra.bundles:
-        typer.echo(f"{b.server.ip}: {b.name} with {len(b.services)} services")
+        typer.echo("No servers found.")
+        raise typer.Exit()
+
+    for bundle in session.infra.bundles:
+        typer.echo(
+            f"{bundle.server.ip} ({bundle.server.uuid}) - {len(bundle.services)} services"
+        )
 
 
-# Register the infra sub-app
-app.add_typer(infra_app, name="infra", help="Infrastructure related commands")
+@server_app.command("add")
+def server_add(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    server_template: str = typer.Option(
+        ..., help="Server template path relative to the stacks directory"
+    ),
+    ip: str = typer.Option(..., help="IP or hostname of the server"),
+    port: int = typer.Option(22, help="SSH port of the server"),
+    root_user: str = typer.Option("root", help="Initial root user"),
+    root_pw: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Root password"
+    ),
+    param: List[str] = typer.Option(
+        [], "--param", help="Additional template parameter in the form KEY=VALUE"
+    ),
+):
+    """Register a new server in the current project."""
+
+    session = get_session(project, password)
+    config = _load_config_from_path(server_template)
+    if not config:
+        typer.echo("[ERROR] Server template not found", err=True)
+        raise typer.Exit(code=1)
+
+    params = {
+        "${MLOX_IP}": ip,
+        "${MLOX_PORT}": str(port),
+        "${MLOX_ROOT}": root_user,
+        "${MLOX_ROOT_PW}": root_pw,
+    }
+    params.update(parse_kv(param))
+
+    bundle = session.infra.add_server(config=config, params=params)
+    if not bundle:
+        typer.echo("[ERROR] Failed to add server", err=True)
+        raise typer.Exit(code=1)
+
+    session.save_infrastructure()
+    typer.echo(f"Added server {ip}")
+
+
+@server_app.command("setup")
+def server_setup(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    ip: str = typer.Argument(..., help="Server IP or hostname"),
+):
+    """Run the setup routine on a server."""
+
+    session = get_session(project, password)
+    bundle = session.infra.get_bundle_by_ip(ip)
+    if not bundle:
+        typer.echo("[ERROR] Server not found", err=True)
+        raise typer.Exit(code=1)
+    bundle.server.setup()
+    session.save_infrastructure()
+    typer.echo(f"Server {ip} set up")
+
+
+@server_app.command("teardown")
+def server_teardown(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    ip: str = typer.Argument(..., help="Server IP or hostname"),
+):
+    """Tear down a server and remove it from the infrastructure."""
+
+    session = get_session(project, password)
+    bundle = session.infra.get_bundle_by_ip(ip)
+    if not bundle:
+        typer.echo("[ERROR] Server not found", err=True)
+        raise typer.Exit(code=1)
+    bundle.server.teardown()
+    session.infra.remove_bundle(bundle)
+    session.save_infrastructure()
+    typer.echo(f"Server {ip} removed")
+
+
+@server_app.command("save-key")
+def server_save_key(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    ip: str = typer.Argument(..., help="Server IP or hostname"),
+    output: str = typer.Option(
+        ..., help="Path to store the encrypted key file",
+    ),
+):
+    """Save a server key file for local access."""
+
+    session = get_session(project, password)
+    bundle = session.infra.get_bundle_by_ip(ip)
+    if not bundle:
+        typer.echo("[ERROR] Server not found", err=True)
+        raise typer.Exit(code=1)
+    server_dict = dataclass_to_dict(bundle.server)
+    save_to_json(server_dict, output, password, True)
+    typer.echo(f"Saved key for {ip} to {output}")
+
+
+# ---------------------------------------------------------------------------
+# Service commands
+# ---------------------------------------------------------------------------
+
+
+@service_app.command("list")
+def service_list(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+):
+    """List services across all servers in the project."""
+
+    session = get_session(project, password)
+    found = False
+    for bundle in session.infra.bundles:
+        for svc in bundle.services:
+            typer.echo(f"{svc.name} ({svc.service_config_id}) on {bundle.server.ip}")
+            found = True
+    if not found:
+        typer.echo("No services found.")
+
+
+@service_app.command("add")
+def service_add(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    server_ip: str = typer.Option(..., help="IP of the target server"),
+    template_id: str = typer.Option(..., help="Service template ID"),
+    param: List[str] = typer.Option(
+        [], "--param", help="Additional template parameter in the form KEY=VALUE"
+    ),
+):
+    """Add a new service to an existing server."""
+
+    session = get_session(project, password)
+    config = load_service_config_by_id(template_id)
+    if not config:
+        typer.echo("[ERROR] Service template not found", err=True)
+        raise typer.Exit(code=1)
+
+    params = parse_kv(param)
+    bundle = session.infra.add_service(server_ip, config, params)
+    if not bundle:
+        typer.echo("[ERROR] Failed to add service", err=True)
+        raise typer.Exit(code=1)
+
+    session.save_infrastructure()
+    svc = bundle.services[-1]
+    typer.echo(f"Added service {svc.name} to {server_ip}")
+
+
+@service_app.command("setup")
+def service_setup(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    name: str = typer.Argument(..., help="Service name"),
+):
+    """Run the setup routine for a service."""
+
+    session = get_session(project, password)
+    svc = session.infra.get_service(name)
+    if not svc:
+        typer.echo("[ERROR] Service not found", err=True)
+        raise typer.Exit(code=1)
+    session.infra.setup_service(svc)
+    session.save_infrastructure()
+    typer.echo(f"Service {name} set up")
+
+
+@service_app.command("teardown")
+def service_teardown(
+    project: str = typer.Argument(..., help="Project name"),
+    password: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="Password for the session"
+    ),
+    name: str = typer.Argument(..., help="Service name"),
+):
+    """Remove a service from the infrastructure."""
+
+    session = get_session(project, password)
+    svc = session.infra.get_service(name)
+    if not svc:
+        typer.echo("[ERROR] Service not found", err=True)
+        raise typer.Exit(code=1)
+    session.infra.teardown_service(svc)
+    session.save_infrastructure()
+    typer.echo(f"Service {name} removed")
+
+
+# ---------------------------------------------------------------------------
+# Template commands
+# ---------------------------------------------------------------------------
+
+
+@template_app.command("servers")
+def template_servers():
+    """List available server templates."""
+
+    configs = load_all_server_configs()
+    for cfg in configs:
+        typer.echo(f"{cfg.id} - {cfg.path}")
+
+
+@template_app.command("services")
+def template_services():
+    """List available service templates."""
+
+    configs = load_all_service_configs()
+    for cfg in configs:
+        typer.echo(f"{cfg.id} - {cfg.path}")
 
 
 if __name__ == "__main__":
     app()
+


### PR DESCRIPTION
## Summary
- overhaul mlox CLI using Typer subcommands for projects, servers, services, and templates
- add project initialization, server/service lifecycle management, and template listings

## Testing
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: No module named 'textual'; ModuleNotFoundError: No module named 'multipass')*

------
https://chatgpt.com/codex/tasks/task_e_68c674c5762483229591653a4257e11d