### PR TITLE
Add MinIO docker service and integration test

### DIFF
--- a/mlox/services/minio/__init__.py
+++ b/mlox/services/minio/__init__.py
@@ -1,0 +1,3 @@
+from .docker import MinioDockerService
+
+__all__ = ["MinioDockerService"]

--- a/mlox/services/minio/docker.py
+++ b/mlox/services/minio/docker.py
@@ -1,0 +1,80 @@
+import logging
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+from mlox.service import AbstractService, tls_setup
+from mlox.remote import (
+    docker_down,
+    exec_command,
+    fs_append_line,
+    fs_copy,
+    fs_create_dir,
+    fs_delete_dir,
+    fs_read_file,
+)
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)s] %(asctime)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+@dataclass
+class MinioDockerService(AbstractService):
+    root_user: str
+    root_password: str
+    api_port: str | int
+    console_port: str | int
+    service_url: str = field(init=False, default="")
+    console_url: str = field(init=False, default="")
+
+    def setup(self, conn) -> None:
+        fs_create_dir(conn, self.target_path)
+        fs_copy(conn, self.template, f"{self.target_path}/{self.target_docker_script}")
+
+        tls_setup(conn, conn.host, self.target_path)
+        self.certificate = fs_read_file(
+            conn, f"{self.target_path}/cert.pem", format="txt/plain"
+        )
+
+        env_path = f"{self.target_path}/{self.target_docker_env}"
+        fs_append_line(conn, env_path, f"MINIO_ROOT_USER={self.root_user}")
+        fs_append_line(conn, env_path, f"MINIO_ROOT_PASSWORD={self.root_password}")
+        fs_append_line(conn, env_path, f"MINIO_PUBLIC_URL={conn.host}")
+        fs_append_line(conn, env_path, f"MINIO_API_PORT={self.api_port}")
+        fs_append_line(conn, env_path, f"MINIO_CONSOLE_PORT={self.console_port}")
+
+        self.service_ports["MinIO API"] = int(self.api_port)
+        self.service_ports["MinIO Console"] = int(self.console_port)
+        self.service_url = f"https://{conn.host}:{self.api_port}"
+        self.console_url = f"https://{conn.host}:{self.console_port}"
+        self.service_urls["MinIO API"] = self.service_url
+        self.service_urls["MinIO Console"] = self.console_url
+
+    def teardown(self, conn):
+        docker_down(
+            conn,
+            f"{self.target_path}/{self.target_docker_script}",
+            remove_volumes=True,
+        )
+        fs_delete_dir(conn, self.target_path)
+
+    def check(self, conn) -> Dict:
+        try:
+            output = exec_command(
+                conn,
+                "docker ps --filter 'name=minio' --filter 'status=running' --format '{{{{.Names}}}}'",
+                sudo=True,
+            )
+            if "minio" in output:
+                self.state = "running"
+                return {"status": "running"}
+            self.state = "stopped"
+            return {"status": "stopped"}
+        except Exception as exc:  # pragma: no cover - defensive logging path
+            logging.error("Error checking MinIO service status: %s", exc)
+            self.state = "unknown"
+        return {"status": "unknown"}

--- a/mlox/services/minio/ui.py
+++ b/mlox/services/minio/ui.py
@@ -1,0 +1,50 @@
+import streamlit as st
+
+from mlox.infra import Infrastructure, Bundle
+from mlox.services.minio.docker import MinioDockerService
+from mlox.services.utils_ui import save_to_secret_store
+
+
+def settings(infra: Infrastructure, bundle: Bundle, service: MinioDockerService):
+    st.write(f"Endpoint: {service.service_url}")
+    st.write(f"Console: {service.console_url}")
+    st.write(f"Root user: {service.root_user}")
+    st.write(f'Root password: "{service.root_password}"')
+
+    save_to_secret_store(
+        infra,
+        f"MLOX_MINIO_{service.name.upper()}",
+        {
+            "api_url": service.service_url,
+            "console_url": service.console_url,
+            "access_key": service.root_user,
+            "secret_key": service.root_password,
+        },
+    )
+
+    st.link_button(
+        "Open MinIO Console",
+        url=service.console_url,
+        icon=":material/open_in_new:",
+        help="Open the MinIO web console",
+    )
+
+    st.code(
+        f"""
+import boto3
+
+s3 = boto3.resource(
+    "s3",
+    endpoint_url="{service.service_url}",
+    aws_access_key_id="{service.root_user}",
+    aws_secret_access_key="{service.root_password}",
+    verify=False,
+)
+        """.strip(),
+        language="python",
+        line_numbers=True,
+    )
+
+    if service.certificate:
+        st.markdown("#### TLS certificate")
+        st.code(service.certificate.strip(), language="bash")

--- a/mlox/stacks/minio/docker-compose-minio.yaml
+++ b/mlox/stacks/minio/docker-compose-minio.yaml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   minio:
-    image: quay.io/minio/minio:RELEASE.2024-09-10T18-08-20Z
+    image: minio/minio:RELEASE.2025-07-23T15-54-02Z-cpuv1
     container_name: minio
     command: server /data --console-address ":9001"
     environment:

--- a/mlox/stacks/minio/docker-compose-minio.yaml
+++ b/mlox/stacks/minio/docker-compose-minio.yaml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  minio:
+    image: quay.io/minio/minio:RELEASE.2024-09-10T18-08-20Z
+    container_name: minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_SERVER_URL: https://${MINIO_PUBLIC_URL:-localhost}:${MINIO_API_PORT:-9000}
+      MINIO_BROWSER_REDIRECT_URL: https://${MINIO_PUBLIC_URL:-localhost}:${MINIO_CONSOLE_PORT:-9001}
+    ports:
+      - ${MINIO_API_PORT:-9000}:9000
+      - ${MINIO_CONSOLE_PORT:-9001}:9001
+    volumes:
+      - minio-data:/data
+      - ./cert.pem:/root/.minio/certs/public.crt:ro
+      - ./key.pem:/root/.minio/certs/private.key:ro
+    restart: unless-stopped
+
+volumes:
+  minio-data:
+    name: minio_data_volume

--- a/mlox/stacks/minio/mlox.minio.RELEASE.2024-09-10.yaml
+++ b/mlox/stacks/minio/mlox.minio.RELEASE.2024-09-10.yaml
@@ -1,0 +1,39 @@
+id: minio-release-2024-09-10-docker
+name: MinIO
+version: "RELEASE.2024-09-10T18-08-20Z"
+maintainer: MLOX Contributors
+description_short: MinIO is a high-performance, S3 compatible object store.
+description: |
+  MinIO is a high-performance, S3 compatible object store designed for large-scale
+  AI/ML, data lake, and database workloads. This stack deploys a single MinIO server
+  secured with a self-signed TLS certificate so you can experiment locally with
+  S3-compatible object storage.
+links:
+  project: https://min.io/
+  documentation: https://min.io/docs/
+  security: https://min.io/docs/minio/linux/operations/site-reliability/security.html
+  changelog: https://github.com/minio/minio/releases
+requirements:
+  cpus: 1.0
+  ram_gb: 2.0
+  disk_gb: 5.0
+groups:
+  service:
+  storage:
+  backend:
+    docker:
+ports:
+  api: 9000
+  console: 9001
+ui:
+  settings: mlox.services.minio.ui.settings
+build:
+  class_name: mlox.services.minio.docker.MinioDockerService
+  params:
+    name: minio-release-2024-09-10
+    template: ${MLOX_STACKS_PATH}/minio/docker-compose-minio.yaml
+    target_path: /home/${MLOX_USER}/minio-release-2024-09-10
+    root_user: ${MLOX_AUTO_USER}
+    root_password: ${MLOX_AUTO_PW}
+    api_port: ${MLOX_AUTO_PORT_API}
+    console_port: ${MLOX_AUTO_PORT_CONSOLE}

--- a/mlox/stacks/minio/mlox.minio.RELEASE.2025-07-23.yaml
+++ b/mlox/stacks/minio/mlox.minio.RELEASE.2025-07-23.yaml
@@ -1,6 +1,6 @@
-id: minio-release-2024-09-10-docker
+id: minio-release-2025-07-23-docker
 name: MinIO
-version: "RELEASE.2024-09-10T18-08-20Z"
+version: "RELEASE.2025-07-23T15-54-02Z-cpuv1"
 maintainer: MLOX Contributors
 description_short: MinIO is a high-performance, S3 compatible object store.
 description: |
@@ -30,9 +30,9 @@ ui:
 build:
   class_name: mlox.services.minio.docker.MinioDockerService
   params:
-    name: minio-release-2024-09-10
+    name: minio-release-2025-07-23
     template: ${MLOX_STACKS_PATH}/minio/docker-compose-minio.yaml
-    target_path: /home/${MLOX_USER}/minio-release-2024-09-10
+    target_path: /home/${MLOX_USER}/minio-release-2025-07-23
     root_user: ${MLOX_AUTO_USER}
     root_password: ${MLOX_AUTO_PW}
     api_port: ${MLOX_AUTO_PORT_API}

--- a/tests/integration/test_service_minio.py
+++ b/tests/integration/test_service_minio.py
@@ -1,0 +1,94 @@
+import shlex
+import pytest
+
+from mlox.config import load_config, get_stacks_path
+from mlox.infra import Infrastructure, Bundle
+
+from tests.integration.conftest import wait_for_service_ready
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def install_minio_service(ubuntu_docker_server):
+    infra = Infrastructure()
+    bundle = Bundle(name=ubuntu_docker_server.ip, server=ubuntu_docker_server)
+    infra.bundles.append(bundle)
+
+    config = load_config(
+        get_stacks_path(), "/minio", "mlox.minio.RELEASE.2024-09-10.yaml"
+    )
+
+    bundle_added = infra.add_service(ubuntu_docker_server.ip, config, params={})
+    if not bundle_added:
+        pytest.skip("Failed to add MinIO service from config")
+
+    bundle = bundle_added
+    service = bundle.services[-1]
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        service.setup(conn)
+        service.spin_up(conn)
+
+    wait_for_service_ready(service, bundle, retries=6, interval=20, no_checks=True)
+
+    yield bundle_added, service
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        try:
+            service.spin_down(conn)
+        except Exception:
+            pass
+        try:
+            service.teardown(conn)
+        except Exception:
+            pass
+    infra.remove_bundle(bundle_added)
+
+
+def test_minio_service_is_installed(install_minio_service):
+    _, service = install_minio_service
+    assert service.service_url
+    assert service.console_url
+    assert service.state == "running"
+
+
+def test_minio_service_is_running(install_minio_service):
+    bundle, service = install_minio_service
+
+    status = wait_for_service_ready(service, bundle, retries=6, interval=20)
+    assert status.get("status") == "running"
+
+
+@pytest.mark.parametrize("bucket", ["mlox-minio-integration"])
+def test_minio_basic_read_write(install_minio_service, bucket):
+    bundle, service = install_minio_service
+
+    endpoint = shlex.quote(service.service_url)
+    access_key = shlex.quote(service.root_user)
+    secret_key = shlex.quote(service.root_password)
+    bucket_target = shlex.quote(f"local/{bucket}")
+    with bundle.server.get_server_connection() as conn:
+        conn.run(
+            "docker run --rm --network host minio/mc sh -c "
+            f"\"mc alias set local {endpoint} {access_key} {secret_key} --insecure "
+            f"&& mc mb --ignore-existing --insecure {bucket_target}\"",
+            hide=False,
+        )
+
+        conn.run(
+            "docker run --rm --network host minio/mc sh -c "
+            f"\"mc alias set local {endpoint} {access_key} {secret_key} --insecure "
+            f"&& printf 'hello from mlox' | mc pipe --insecure {bucket_target}/sample.txt\"",
+            hide=False,
+        )
+
+        result = conn.run(
+            "docker run --rm --network host minio/mc sh -c "
+            f"\"mc alias set local {endpoint} {access_key} {secret_key} --insecure "
+            f"&& mc cat --insecure {bucket_target}/sample.txt\"",
+            hide=True,
+        )
+
+    assert "hello from mlox" in result.stdout


### PR DESCRIPTION
## Summary
- add a MinIO stack definition and Docker Compose template that provisions a TLS-enabled single-node object store
- implement the MinIO Docker service plus Streamlit UI wiring for credentials and console access
- cover the new service with an integration test that provisions MinIO and exercises basic bucket read/write via the MinIO client

## Testing
- PYTHONPATH=. pytest tests/integration/test_service_minio.py *(fails: ModuleNotFoundError for textual in test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd563181088322ba32b196cbaa3792