### PR TITLE
Add Kafka docker service with TLS and integration tests

### DIFF
--- a/mlox/services/Kafka/__init__.py
+++ b/mlox/services/Kafka/__init__.py
@@ -1,0 +1,5 @@
+"""Kafka service package."""
+
+from .docker import KafkaDockerService
+
+__all__ = ["KafkaDockerService"]

--- a/mlox/services/Kafka/ui.py
+++ b/mlox/services/Kafka/ui.py
@@ -1,0 +1,64 @@
+import textwrap
+import streamlit as st
+
+from mlox.infra import Infrastructure, Bundle
+from mlox.services.Kafka.docker import KafkaDockerService
+from mlox.services.utils_ui import save_to_secret_store
+
+
+def settings(infra: Infrastructure, bundle: Bundle, service: KafkaDockerService):
+    st.write(f"Bootstrap server: {service.service_url}")
+    st.write(f"SSL port: {service.service_ports.get('Kafka SSL')}")
+
+    save_to_secret_store(
+        infra,
+        f"MLOX_KAFKA_{service.name.upper()}",
+        {
+            "bootstrap_server": service.service_url,
+            "ssl_port": service.service_ports.get("Kafka SSL"),
+            "certificate": service.certificate,
+        },
+    )
+
+    st.code(
+        textwrap.dedent(
+            f"""
+            from kafka import KafkaProducer, KafkaConsumer
+
+            bootstrap = "{bundle.server.ip}:{service.service_ports.get('Kafka SSL')}"
+            cafile_path = "./kafka-ca.pem"
+
+            # Producer example
+            producer = KafkaProducer(
+                bootstrap_servers=[bootstrap],
+                security_protocol="SSL",
+                ssl_cafile=cafile_path,
+                ssl_check_hostname=False,
+            )
+            producer.send("demo-topic", b"hello from mlox")
+            producer.flush()
+            producer.close()
+
+            # Consumer example
+            consumer = KafkaConsumer(
+                "demo-topic",
+                bootstrap_servers=[bootstrap],
+                security_protocol="SSL",
+                ssl_cafile=cafile_path,
+                ssl_check_hostname=False,
+                auto_offset_reset="earliest",
+                enable_auto_commit=False,
+            )
+            for message in consumer:
+                print(message.value)
+                break
+            consumer.close()
+            """
+        ).strip(),
+        language="python",
+        line_numbers=True,
+    )
+
+    if service.certificate:
+        st.markdown("#### TLS certificate")
+        st.code(service.certificate.strip(), language="bash")

--- a/mlox/stacks/kafka/docker-compose-kafka-3.7.0.yaml
+++ b/mlox/stacks/kafka/docker-compose-kafka-3.7.0.yaml
@@ -1,0 +1,46 @@
+version: "3.8"
+
+services:
+  kafka:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka
+    restart: unless-stopped
+    ports:
+      - ${KAFKA_SSL_PORT:-9094}:9094
+    environment:
+      - BITNAMI_DEBUG=true
+      - KAFKA_ENABLE_KRAFT=yes
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_LISTENERS=CONTROLLER://:9093,INTERNAL://:9092,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CONTROLLER://kafka:9093,INTERNAL://kafka:9092,EXTERNAL://${KAFKA_PUBLIC_HOST}:${KAFKA_SSL_PORT}
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:SSL
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_SSL_CLIENT_AUTH=none
+      - KAFKA_CFG_SSL_KEYSTORE_LOCATION=/certs/kafka.keystore.p12
+      - KAFKA_CFG_SSL_KEYSTORE_PASSWORD=${KAFKA_SSL_PASSWORD}
+      - KAFKA_CFG_SSL_KEYSTORE_TYPE=PKCS12
+      - KAFKA_CFG_SSL_TRUSTSTORE_LOCATION=/certs/kafka.truststore.p12
+      - KAFKA_CFG_SSL_TRUSTSTORE_PASSWORD=${KAFKA_SSL_PASSWORD}
+      - KAFKA_CFG_SSL_TRUSTSTORE_TYPE=PKCS12
+      - KAFKA_CFG_SSL_KEY_PASSWORD=${KAFKA_SSL_PASSWORD}
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+    volumes:
+      - ./kafka.keystore.p12:/certs/kafka.keystore.p12:ro
+      - ./kafka.truststore.p12:/certs/kafka.truststore.p12:ro
+    healthcheck:
+      test: ["CMD", "bash", "-c", "kafka-topics.sh --bootstrap-server localhost:9092 --list"]
+      interval: 10s
+      timeout: 10s
+      retries: 6
+      start_period: 20s
+
+volumes: {}
+
+networks: {}

--- a/mlox/stacks/kafka/mlox.kafka.3.7.0.yaml
+++ b/mlox/stacks/kafka/mlox.kafka.3.7.0.yaml
@@ -1,0 +1,37 @@
+id: kafka-3.7.0-docker
+name: Apache Kafka
+version: "3.7.0"
+maintainer: Your Name
+description_short: Apache Kafka is a distributed event streaming platform for high-performance data pipelines.
+description: |
+  Apache Kafka is an open-source distributed event streaming platform capable of
+  handling trillions of events a day. In MLOX it can be used for building real-time
+  data pipelines, streaming analytics, and integrating machine learning workloads
+  that rely on reliable event delivery. This stack deploys a single-node Kafka broker
+  secured with self-signed TLS certificates suitable for development and testing.
+links:
+  project: https://kafka.apache.org/
+  documentation: https://kafka.apache.org/documentation/
+  changelog: https://kafka.apache.org/downloads
+requirements:
+  cpus: 2.0
+  ram_gb: 4.0
+  disk_gb: 2.0
+groups:
+  service:
+  messaging:
+  streaming:
+  backend:
+    docker:
+ports:  # These are 'preferred' ports, they can and possibly will be changed by automation
+  ssl: 9094
+ui:
+  settings: mlox.services.Kafka.ui.settings
+build:
+  class_name: mlox.services.Kafka.docker.KafkaDockerService
+  params:
+    name: kafka-3.7.0
+    template: ${MLOX_STACKS_PATH}/kafka/docker-compose-kafka-3.7.0.yaml
+    target_path: /home/${MLOX_USER}/kafka-3.7.0
+    ssl_password: ${MLOX_AUTO_PW}
+    ssl_port: ${MLOX_AUTO_PORT_SERVICE}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "passlib==1.7.4",  # M
     "typer==0.17.4",  # M               # CLI helpers
     "grpcio==1.73.1",  # M
+    "kafka-python==2.0.2",
     # "bcrypt>=4.0",
     # "requests>=2.31",
     # "python-dotenv>=1.0",

--- a/tests/integration/test_service_kafka.py
+++ b/tests/integration/test_service_kafka.py
@@ -1,0 +1,106 @@
+import uuid
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("kafka")
+from kafka import KafkaConsumer, KafkaProducer  # type: ignore
+
+from mlox.config import get_stacks_path, load_config
+from mlox.infra import Bundle, Infrastructure
+
+from tests.integration.conftest import wait_for_service_ready
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def install_kafka_service(ubuntu_docker_server):
+    infra = Infrastructure()
+    bundle = Bundle(name=ubuntu_docker_server.ip, server=ubuntu_docker_server)
+    infra.bundles.append(bundle)
+
+    config = load_config(get_stacks_path(), "/kafka", "mlox.kafka.3.7.0.yaml")
+
+    bundle_added = infra.add_service(ubuntu_docker_server.ip, config, params={})
+    if not bundle_added:
+        pytest.skip("Failed to add Kafka service from config")
+
+    bundle = bundle_added
+    service = bundle.services[-1]
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        service.setup(conn)
+        service.spin_up(conn)
+
+    wait_for_service_ready(service, bundle, retries=12, interval=10)
+
+    yield bundle, service
+
+    with ubuntu_docker_server.get_server_connection() as conn:
+        try:
+            service.spin_down(conn)
+        except Exception:
+            pass
+        try:
+            service.teardown(conn)
+        except Exception:
+            pass
+    infra.remove_bundle(bundle)
+
+
+def _write_certificate(tmp_path: Path, certificate: str) -> Path:
+    cafile = tmp_path / "kafka-ca.pem"
+    cafile.write_text(certificate)
+    return cafile
+
+
+def test_kafka_service_is_installed(install_kafka_service):
+    _, service = install_kafka_service
+    assert service.service_url
+    assert service.state == "running"
+
+
+def test_kafka_service_is_running(install_kafka_service):
+    bundle, service = install_kafka_service
+    status = wait_for_service_ready(service, bundle, retries=6, interval=10)
+    assert status.get("status") == "running"
+
+
+@pytest.mark.parametrize("topic", ["mlox-integration-topic"])
+def test_kafka_basic_read_write(install_kafka_service, tmp_path, topic):
+    bundle, service = install_kafka_service
+
+    cafile = _write_certificate(tmp_path, service.certificate)
+    bootstrap = f"{bundle.server.ip}:{service.service_ports['Kafka SSL']}"
+    message = b"hello from mlox kafka"
+
+    producer = KafkaProducer(
+        bootstrap_servers=[bootstrap],
+        security_protocol="SSL",
+        ssl_cafile=str(cafile),
+        ssl_check_hostname=False,
+    )
+
+    future = producer.send(topic, message)
+    future.get(timeout=30)
+    producer.flush()
+    producer.close()
+
+    consumer = KafkaConsumer(
+        topic,
+        bootstrap_servers=[bootstrap],
+        security_protocol="SSL",
+        ssl_cafile=str(cafile),
+        ssl_check_hostname=False,
+        auto_offset_reset="earliest",
+        enable_auto_commit=False,
+        group_id=f"mlox-integration-{uuid.uuid4().hex[:8]}",
+        consumer_timeout_ms=15000,
+    )
+
+    received = [record.value for record in consumer]
+    consumer.close()
+
+    assert message in received


### PR DESCRIPTION
## Summary
- add a Kafka stack definition and docker compose template secured with self-signed TLS
- implement a Kafka docker service and Streamlit UI helper for exposing connection details
- add integration coverage for Kafka installation, runtime status, and SSL producer/consumer interactions
- include kafka-python dependency for Kafka client interactions in tests and UI samples

## Testing
- `PYTHONPATH=. pytest tests/integration/test_service_kafka.py -k installed` *(fails: ModuleNotFoundError: No module named 'textual')*

------
https://chatgpt.com/codex/tasks/task_e_68ce84c945b88322b490169638f7132d