### PR TITLE
Return structured secret payloads for services

### DIFF
--- a/mlox/service.py
+++ b/mlox/service.py
@@ -103,6 +103,11 @@ class AbstractService(ABC):
     def check(self, conn) -> Dict:
         pass
 
+    @abstractmethod
+    def get_secrets(self) -> Dict[str, Dict]:
+        """Return a mapping of secret identifiers to structured secret payloads."""
+        raise NotImplementedError
+
     def spin_up(self, conn) -> bool:
         """Start the service.
 

--- a/mlox/services/Kafka/docker.py
+++ b/mlox/services/Kafka/docker.py
@@ -130,3 +130,8 @@ class KafkaDockerService(AbstractService):
             logger.error("Error checking Kafka service status: %s", exc)
             self.state = "unknown"
             return {"status": "unknown", "error": str(exc)}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        if not self.ssl_password:
+            return {}
+        return {"kafka_ssl_credentials": {"password": self.ssl_password}}

--- a/mlox/services/airflow/docker.py
+++ b/mlox/services/airflow/docker.py
@@ -139,3 +139,16 @@ class AirflowDockerService(AbstractService):
                 f"An unexpected error occurred during Airflow health check for {url}: {e}"
             )
             return {"status": "unknown", "message": f"Error: {e}"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.ui_user,
+                "password": self.ui_pw,
+            }.items()
+            if value
+        }
+        if not credentials:
+            return {}
+        return {"airflow_ui_credentials": credentials}

--- a/mlox/services/feast/docker.py
+++ b/mlox/services/feast/docker.py
@@ -87,3 +87,6 @@ class FeastDockerService(AbstractService):
 
     def check(self, conn) -> Dict:
         return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/gcp/bq_service.py
+++ b/mlox/services/gcp/bq_service.py
@@ -55,3 +55,6 @@ class GCPBigQueryService(AbstractService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/gcp/secret_service.py
+++ b/mlox/services/gcp/secret_service.py
@@ -51,3 +51,7 @@ class GCPSecretService(AbstractService, AbstractSecretManagerService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}
+    

--- a/mlox/services/gcp/sheet_service.py
+++ b/mlox/services/gcp/sheet_service.py
@@ -56,3 +56,6 @@ class GCPSpreadsheetsService(AbstractService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/gcp/storage_service.py
+++ b/mlox/services/gcp/storage_service.py
@@ -55,3 +55,6 @@ class GCPStorageService(AbstractService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/github/service.py
+++ b/mlox/services/github/service.py
@@ -110,6 +110,11 @@ class GithubRepoService(AbstractService, Repo):
             "tree": repo_tree,
         }
 
+    def get_secrets(self) -> Dict[str, Dict]:
+        if not self.deploy_key:
+            return {}
+        return {"github_deploy_key": {"key": self.deploy_key}}
+
     def _generate_deploy_ssh_key(
         self,
         conn,

--- a/mlox/services/influx/docker.py
+++ b/mlox/services/influx/docker.py
@@ -85,3 +85,17 @@ class InfluxDockerService(AbstractService):
             logging.error(f"Error checking InfluxDB service status: {e}")
             self.state = "unknown"
         return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.user,
+                "password": self.pw,
+                "token": self.token,
+            }.items()
+            if value
+        }
+        if not credentials:
+            return {}
+        return {"influx_admin_credentials": credentials}

--- a/mlox/services/k8s_dashboard/k8s.py
+++ b/mlox/services/k8s_dashboard/k8s.py
@@ -214,3 +214,6 @@ class K8sDashboardService(AbstractService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/k8s_headlamp/k8s.py
+++ b/mlox/services/k8s_headlamp/k8s.py
@@ -95,3 +95,6 @@ class K8sHeadlampService(AbstractService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/kubeapps/k8s.py
+++ b/mlox/services/kubeapps/k8s.py
@@ -231,3 +231,6 @@ class KubeAppsService(AbstractService):
 
         # return {"status": "unknown", "details": "Could not determine KubeApps status."}
         return {"status": helm_result}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/litellm/docker.py
+++ b/mlox/services/litellm/docker.py
@@ -87,3 +87,25 @@ class LiteLLMDockerService(AbstractService):
 
     def check(self, conn) -> Dict:
         return dict()
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        secrets: Dict[str, Dict] = {}
+
+        if self.api_key:
+            secrets["litellm_api_access"] = {"api_key": self.api_key}
+
+        if self.slack_webhook:
+            secrets["litellm_slack_alerting"] = {"webhook_url": self.slack_webhook}
+
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.ui_user,
+                "password": self.ui_pw,
+            }.items()
+            if value
+        }
+        if credentials:
+            secrets["litellm_ui_credentials"] = credentials
+
+        return secrets

--- a/mlox/services/milvus/docker.py
+++ b/mlox/services/milvus/docker.py
@@ -83,3 +83,16 @@ class MilvusDockerService(AbstractService):
 
     def check(self, conn) -> Dict:
         return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.user,
+                "password": self.pw,
+            }.items()
+            if value
+        }
+        if not credentials:
+            return {}
+        return {"milvus_credentials": credentials}

--- a/mlox/services/minio/docker.py
+++ b/mlox/services/minio/docker.py
@@ -97,3 +97,16 @@ class MinioDockerService(AbstractService):
             logging.error("Error checking MinIO service status: %s", exc)
             self.state = "unknown"
         return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.root_user,
+                "password": self.root_password,
+            }.items()
+            if value
+        }
+        if not credentials:
+            return {}
+        return {"minio_root_credentials": credentials}

--- a/mlox/services/mlflow/docker.py
+++ b/mlox/services/mlflow/docker.py
@@ -97,3 +97,16 @@ class MLFlowDockerService(AbstractService):
             "status": "unknown",
             "message": "MLflow API not reachable",
         }
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.ui_user,
+                "password": self.ui_pw,
+            }.items()
+            if value
+        }
+        if not credentials:
+            return {}
+        return {"mlflow_ui_credentials": credentials}

--- a/mlox/services/mlflow_mlserver/docker.py
+++ b/mlox/services/mlflow_mlserver/docker.py
@@ -97,3 +97,30 @@ class MLFlowMLServerDockerService(AbstractService):
 
     def check(self, conn) -> Dict:
         return {}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        secrets: Dict[str, Dict] = {}
+
+        basic_auth = {
+            key: value
+            for key, value in {
+                "username": self.user,
+                "password": self.pw,
+            }.items()
+            if value
+        }
+        if basic_auth:
+            secrets["mlserver_basic_auth"] = basic_auth
+
+        tracking_auth = {
+            key: value
+            for key, value in {
+                "username": self.tracking_user,
+                "password": self.tracking_pw,
+            }.items()
+            if value
+        }
+        if tracking_auth:
+            secrets["mlflow_tracking_credentials"] = tracking_auth
+
+        return secrets

--- a/mlox/services/otel/docker.py
+++ b/mlox/services/otel/docker.py
@@ -118,3 +118,16 @@ class OtelDockerService(AbstractService):
             status = "starting"
 
         return {"status": status, "docker_state": docker_state}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        payload = {
+            key: value
+            for key, value in {
+                "license_key": self.relic_key,
+                "endpoint": self.relic_endpoint,
+            }.items()
+            if value
+        }
+        if not payload:
+            return {}
+        return {"new_relic_exporter": payload}

--- a/mlox/services/postgres/docker.py
+++ b/mlox/services/postgres/docker.py
@@ -83,3 +83,16 @@ class PostgresDockerService(AbstractService):
             logging.error(f"Error checking Redis service status: {e}")
             self.state = "unknown"
         return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        credentials = {
+            key: value
+            for key, value in {
+                "username": self.user,
+                "password": self.pw,
+            }.items()
+            if value
+        }
+        if not credentials:
+            return {}
+        return {"postgres_admin_credentials": credentials}

--- a/mlox/services/redis/docker.py
+++ b/mlox/services/redis/docker.py
@@ -88,3 +88,8 @@ class RedisDockerService(AbstractService):
             logging.error(f"Error checking Redis service status: {e}")
             self.state = "unknown"
         return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        if not self.pw:
+            return {}
+        return {"redis_auth": {"password": self.pw}}

--- a/mlox/services/tsm/service.py
+++ b/mlox/services/tsm/service.py
@@ -81,6 +81,11 @@ class TSMService(AbstractService, AbstractSecretManagerService):
     def check(self, conn) -> Dict:
         return dict()
 
+    def get_secrets(self) -> Dict[str, Dict]:
+        if not self.pw:
+            return {}
+        return {"tsm_secrets_vault": {"password": self.pw}}
+
 
 def load_secret_manager_from_keyfile(path: str, pw: str) -> AbstractSecretManager:
     """

--- a/tests/unit/test_service_secrets.py
+++ b/tests/unit/test_service_secrets.py
@@ -1,0 +1,292 @@
+import pytest
+
+from mlox.services.Kafka.docker import KafkaDockerService
+from mlox.services.airflow.docker import AirflowDockerService
+from mlox.services.feast.docker import FeastDockerService
+from mlox.services.gcp.bq_service import GCPBigQueryService
+from mlox.services.gcp.secret_service import GCPSecretService
+from mlox.services.gcp.sheet_service import GCPSpreadsheetsService
+from mlox.services.gcp.storage_service import GCPStorageService
+from mlox.services.github.service import GithubRepoService
+from mlox.services.influx.docker import InfluxDockerService
+from mlox.services.k8s_dashboard.k8s import K8sDashboardService
+from mlox.services.k8s_headlamp.k8s import K8sHeadlampService
+from mlox.services.kubeapps.k8s import KubeAppsService
+from mlox.services.litellm.docker import LiteLLMDockerService
+from mlox.services.milvus.docker import MilvusDockerService
+from mlox.services.minio.docker import MinioDockerService
+from mlox.services.mlflow.docker import MLFlowDockerService
+from mlox.services.mlflow_mlserver.docker import MLFlowMLServerDockerService
+from mlox.services.otel.docker import OtelDockerService
+from mlox.services.postgres.docker import PostgresDockerService
+from mlox.services.redis.docker import RedisDockerService
+from mlox.services.tsm.service import TSMService
+
+
+BASE_KWARGS = {
+    "name": "test-service",
+    "service_config_id": "cfg-id",
+    "template": "/tmp/template",
+    "target_path": "/tmp/target",
+}
+
+
+def _set_github_deploy_key(service: GithubRepoService) -> None:
+    service.deploy_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD"
+
+
+SERVICE_CASES = [
+    (
+        AirflowDockerService,
+        {
+            "path_dags": "/dags",
+            "path_output": "/output",
+            "ui_user": "airflow",
+            "ui_pw": "airflowpw",
+            "port": "8080",
+        },
+        {
+            "airflow_ui_credentials": {
+                "username": "airflow",
+                "password": "airflowpw",
+            },
+        },
+        None,
+    ),
+    (
+        RedisDockerService,
+        {"pw": "redispass", "port": "6379"},
+        {"redis_auth": {"password": "redispass"}},
+        None,
+    ),
+    (
+        KafkaDockerService,
+        {"ssl_password": "sslpass", "ssl_port": "9093"},
+        {"kafka_ssl_credentials": {"password": "sslpass"}},
+        None,
+    ),
+    (
+        KubeAppsService,
+        {},
+        {},
+        None,
+    ),
+    (
+        FeastDockerService,
+        {
+            "config": "config.yaml",
+            "dockerfile": "Dockerfile",
+            "registry_port": "6565",
+            "online_port": "6566",
+            "offline_port": "6567",
+        },
+        {},
+        None,
+    ),
+    (
+        LiteLLMDockerService,
+        {
+            "ollama_script": "entrypoint.sh",
+            "litellm_config": "config.yaml",
+            "ui_user": "litellm",
+            "ui_pw": "litellm-pass",
+            "ui_port": "8000",
+            "service_port": "8081",
+            "slack_webhook": "https://hooks.slack.com/services/test",
+            "api_key": "llm-api-key",
+        },
+        {
+            "litellm_api_access": {"api_key": "llm-api-key"},
+            "litellm_slack_alerting": {
+                "webhook_url": "https://hooks.slack.com/services/test",
+            },
+            "litellm_ui_credentials": {
+                "username": "litellm",
+                "password": "litellm-pass",
+            },
+        },
+        None,
+    ),
+    (
+        GithubRepoService,
+        {"link": "https://github.com/example/repo", "is_private": True},
+        {
+            "github_deploy_key": {
+                "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD",
+            },
+        },
+        _set_github_deploy_key,
+    ),
+    (
+        MLFlowMLServerDockerService,
+        {
+            "dockerfile": "Dockerfile",
+            "port": "5005",
+            "model": "model",
+            "tracking_uri": "https://mlflow.example.com",
+            "tracking_user": "tracking",
+            "tracking_pw": "tracking-pass",
+            "user": "mlserver",
+            "pw": "mlserver-pass",
+        },
+        {
+            "mlserver_basic_auth": {
+                "username": "mlserver",
+                "password": "mlserver-pass",
+            },
+            "mlflow_tracking_credentials": {
+                "username": "tracking",
+                "password": "tracking-pass",
+            },
+        },
+        None,
+    ),
+    (
+        InfluxDockerService,
+        {
+            "user": "influx",
+            "pw": "influx-pass",
+            "port": "8086",
+            "token": "influx-token",
+        },
+        {
+            "influx_admin_credentials": {
+                "username": "influx",
+                "password": "influx-pass",
+                "token": "influx-token",
+            },
+        },
+        None,
+    ),
+    (
+        GCPStorageService,
+        {"secret_name": "storage-key", "secret_manager_uuid": "uuid"},
+        {},
+        None,
+    ),
+    (
+        MinioDockerService,
+        {
+            "root_user": "minio",
+            "root_password": "minio-pass",
+            "api_port": "9000",
+            "console_port": "9001",
+        },
+        {
+            "minio_root_credentials": {
+                "username": "minio",
+                "password": "minio-pass",
+            },
+        },
+        None,
+    ),
+    (
+        MilvusDockerService,
+        {
+            "config": "milvus.yaml",
+            "user": "milvus",
+            "pw": "milvus-pass",
+            "port": "19530",
+        },
+        {
+            "milvus_credentials": {
+                "username": "milvus",
+                "password": "milvus-pass",
+            },
+        },
+        None,
+    ),
+    (
+        TSMService,
+        {"pw": "tsm-pass", "server_uuid": "server-uuid"},
+        {"tsm_secrets_vault": {"password": "tsm-pass"}},
+        None,
+    ),
+    (
+        GCPSecretService,
+        {"secret_name": "gcp-secret", "secret_manager_uuid": "uuid"},
+        {},
+        None,
+    ),
+    (
+        K8sDashboardService,
+        {},
+        {},
+        None,
+    ),
+    (
+        GCPSpreadsheetsService,
+        {"secret_name": "sheets", "secret_manager_uuid": "uuid"},
+        {},
+        None,
+    ),
+    (
+        GCPBigQueryService,
+        {"secret_name": "bq", "secret_manager_uuid": "uuid"},
+        {},
+        None,
+    ),
+    (
+        PostgresDockerService,
+        {
+            "user": "postgres",
+            "pw": "postgres-pass",
+            "db": "postgres-db",
+            "port": "5432",
+        },
+        {
+            "postgres_admin_credentials": {
+                "username": "postgres",
+                "password": "postgres-pass",
+            },
+        },
+        None,
+    ),
+    (
+        MLFlowDockerService,
+        {"ui_user": "mlflow", "ui_pw": "mlflow-pass", "port": "5000"},
+        {
+            "mlflow_ui_credentials": {
+                "username": "mlflow",
+                "password": "mlflow-pass",
+            },
+        },
+        None,
+    ),
+    (
+        OtelDockerService,
+        {
+            "relic_endpoint": "https://otlp.nr.example.com",
+            "relic_key": "nr-key",
+            "config": "otel.yaml",
+            "port_grpc": "4317",
+            "port_http": "4318",
+            "port_health": "13133",
+        },
+        {
+            "new_relic_exporter": {
+                "license_key": "nr-key",
+                "endpoint": "https://otlp.nr.example.com",
+            },
+        },
+        None,
+    ),
+    (
+        K8sHeadlampService,
+        {},
+        {},
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "service_cls, extra_kwargs, expected, post_init",
+    SERVICE_CASES,
+)
+def test_service_get_secrets(service_cls, extra_kwargs, expected, post_init):
+    kwargs = {**BASE_KWARGS, **extra_kwargs}
+    service = service_cls(**kwargs)
+    if post_init is not None:
+        post_init(service)
+    assert service.get_secrets() == expected


### PR DESCRIPTION
## Summary
- require `AbstractService.get_secrets` to return structured secret payloads
- update service implementations to emit nested dictionaries of credentials and tokens
- refresh the service secret unit test expectations for the new schema

## Testing
- pytest tests/unit/test_service_secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dcd4b4d28c8322af4220e88b06decd