### PR TITLE
Add service capability enum, mixins, and validation

### DIFF
--- a/mlox/config.py
+++ b/mlox/config.py
@@ -7,7 +7,14 @@ from importlib import resources, metadata as importlib_metadata
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, TypedDict
 
-from mlox.service import AbstractService
+from mlox.service import (
+    AbstractModelRegistryService,
+    AbstractModelServerService,
+    AbstractRepositoryService,
+    AbstractSecretManagerService,
+    AbstractService,
+    ServiceCapability,
+)
 from mlox.server import (
     AbstractDockerServer,
     AbstractFirewallServer,
@@ -25,7 +32,7 @@ from mlox.ui.registry import get_handler
 PluginKind = Literal["service", "server"]
 
 
-CAPABILITY_ABCS = {
+SERVER_CAPABILITY_ABCS = {
     ServerCapability.GIT.value: AbstractGitServer,
     ServerCapability.FIREWALL.value: AbstractFirewallServer,
     ServerCapability.INITIAL_AUTH_PASSWORD.value: AbstractInitialPasswordAuthServer,
@@ -36,10 +43,40 @@ CAPABILITY_ABCS = {
 }
 
 
+SERVICE_CAPABILITY_ABCS = {
+    ServiceCapability.SECRET_MANAGER.value: AbstractSecretManagerService,
+    ServiceCapability.REPOSITORY.value: AbstractRepositoryService,
+    ServiceCapability.MODEL_REGISTRY.value: AbstractModelRegistryService,
+    ServiceCapability.MODEL_SERVER.value: AbstractModelServerService,
+}
+
+SERVICE_GROUP_ALIASES = {
+    "secret_manager": ServiceCapability.SECRET_MANAGER.value,
+    "repository": ServiceCapability.REPOSITORY.value,
+    "git": ServiceCapability.REPOSITORY.value,
+    "model_registry": ServiceCapability.MODEL_REGISTRY.value,
+    "model_server": ServiceCapability.MODEL_SERVER.value,
+    "observability": ServiceCapability.OBSERVABILITY.value,
+    "data_warehouse": ServiceCapability.DATA_WAREHOUSE.value,
+    "object_storage": ServiceCapability.OBJECT_STORAGE.value,
+    "spreadsheet": ServiceCapability.SPREADSHEET.value,
+    "database": ServiceCapability.DATABASE.value,
+    "vector_database": ServiceCapability.VECTOR_DATABASE.value,
+    "cache": ServiceCapability.CACHE.value,
+    "message_broker": ServiceCapability.MESSAGE_BROKER.value,
+    "workflow_orchestrator": ServiceCapability.WORKFLOW_ORCHESTRATOR.value,
+    "feature_store": ServiceCapability.FEATURE_STORE.value,
+    "container_registry": ServiceCapability.CONTAINER_REGISTRY.value,
+    "deployment": ServiceCapability.DEPLOYMENT.value,
+    "llm": ServiceCapability.LLM.value,
+    "dashboard": ServiceCapability.DASHBOARD.value,
+}
+
+
 def _normalize_capability_name(value: Any) -> str:
-    if isinstance(value, ServerCapability):
+    if isinstance(value, (ServerCapability, ServiceCapability)):
         return value.value
-    return str(value).strip().lower()
+    return str(value).strip().lower().replace("-", "_")
 
 
 def _normalize_capability_values(value: Any) -> set[str]:
@@ -61,7 +98,7 @@ def _normalize_capability_map(capabilities: Dict[str, Any]) -> Dict[str, set[str
 
 
 def _capabilities_from_groups(groups: Dict[str, Any]) -> Dict[str, set[str]]:
-    derived: Dict[str, set[str]] = {"server": set(), "backend": set()}
+    derived: Dict[str, set[str]] = {"server": set(), "backend": set(), "service": set()}
 
     server_groups = groups.get("server")
     if isinstance(server_groups, dict):
@@ -71,6 +108,12 @@ def _capabilities_from_groups(groups: Dict[str, Any]) -> Dict[str, set[str]]:
     if isinstance(backend_groups, dict):
         for backend in backend_groups.keys():
             derived["backend"].add(_normalize_capability_name(backend))
+
+    for group in groups.keys():
+        group_name = _normalize_capability_name(group)
+        capability = SERVICE_GROUP_ALIASES.get(group_name)
+        if capability:
+            derived["service"].add(capability)
 
     return {section: values for section, values in derived.items() if values}
 
@@ -90,11 +133,19 @@ def _load_build_class(config: "ServiceConfig") -> type | None:
     return build_class
 
 
-def _server_class_capabilities(server_class: type) -> set[str]:
+def _class_capabilities(build_class: type) -> set[str]:
     return {
         _normalize_capability_name(capability)
-        for capability in getattr(server_class, "capabilities", set())
+        for capability in getattr(build_class, "capabilities", set())
     }
+
+
+def _server_class_capabilities(server_class: type) -> set[str]:
+    return _class_capabilities(server_class)
+
+
+def _service_class_capabilities(service_class: type) -> set[str]:
+    return _class_capabilities(service_class)
 
 
 def _validate_server_config_capabilities(config: "ServiceConfig") -> None:
@@ -138,13 +189,66 @@ def _validate_server_config_capabilities(config: "ServiceConfig") -> None:
         )
 
     for capability in sorted(declared_known):
-        required_abc = CAPABILITY_ABCS.get(capability)
+        required_abc = SERVER_CAPABILITY_ABCS.get(capability)
         if required_abc and not issubclass(server_class, required_abc):
             logging.warning(
                 "Server config %s declares capability %s but %s does not implement %s",
                 config.id,
                 capability,
                 server_class.__name__,
+                required_abc.__name__,
+            )
+
+
+def _validate_service_config_capabilities(config: "ServiceConfig") -> None:
+    service_class = _load_build_class(config)
+    if service_class is None:
+        return
+    if not isinstance(service_class, type) or not issubclass(
+        service_class, AbstractService
+    ):
+        return
+
+    declared = config.service_capabilities()
+    known = {capability.value for capability in ServiceCapability}
+    unknown = declared - known
+    if unknown:
+        logging.warning(
+            "Service config %s declares unknown service capabilities: %s",
+            config.id,
+            sorted(unknown),
+        )
+
+    declared_known = declared & known
+    class_capabilities = _service_class_capabilities(service_class)
+    class_service_capabilities = class_capabilities & known
+
+    missing_from_class = declared_known - class_service_capabilities
+    if missing_from_class:
+        logging.warning(
+            "Service config %s declares service capabilities not supported by %s: %s",
+            config.id,
+            service_class.__name__,
+            sorted(missing_from_class),
+        )
+
+    missing_from_config = class_service_capabilities - declared_known
+    if missing_from_config:
+        logging.warning(
+            "Service class %s supports service capabilities not advertised by config %s: %s",
+            service_class.__name__,
+            config.id,
+            sorted(missing_from_config),
+        )
+
+    for capability in sorted(declared_known):
+        required_abc = SERVICE_CAPABILITY_ABCS.get(capability)
+        if required_abc and not issubclass(service_class, required_abc):
+            logging.warning(
+                "Service config %s declares capability %s but %s does not implement %s",
+                config.id,
+                capability,
+                service_class.__name__,
                 required_abc.__name__,
             )
 
@@ -181,6 +285,9 @@ class ServiceConfig:
 
     def backend_capabilities(self) -> set[str]:
         return self.declared_capabilities().get("backend", set())
+
+    def service_capabilities(self) -> set[str]:
+        return self.declared_capabilities().get("service", set())
 
     def get_ui_handler(self, frontend: str, function_name: str) -> Callable | None:
         return get_handler(
@@ -364,6 +471,8 @@ def load_config(
             service_config_instance.path = f"{service_dir}/{candidate}"
             if candidate.startswith("mlox-server."):
                 _validate_server_config_capabilities(service_config_instance)
+            else:
+                _validate_service_config_capabilities(service_config_instance)
             return service_config_instance
 
         except yaml.YAMLError as e:

--- a/mlox/infra.py
+++ b/mlox/infra.py
@@ -19,11 +19,9 @@ Related modules (plain-text links):
 - mlox.session
 """
 
-from abc import abstractmethod
 from collections.abc import Generator
 import logging
 
-from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Optional, List, Literal, Dict, Any
 
@@ -31,43 +29,18 @@ from mlox.config import (
     ServiceConfig,
 )
 from mlox.server import AbstractServer, ServerCapability
-from mlox.service import AbstractService
+from mlox.service import (
+    AbstractModelRegistryService as ModelRegistry,
+    AbstractModelServerService as ModelServer,
+    AbstractRepositoryService as Repo,
+    AbstractService,
+)
 from mlox.utils import (
     dataclass_to_dict,
     dict_to_dataclass,
 )
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class ModelRegistry:
-    @abstractmethod
-    def list_models(self, filter: str | None = None) -> List[Dict[str, Any]]:
-        pass
-
-
-@dataclass
-class ModelServer:
-    # kw_only avoids default-before-required ordering problems in subclasses
-    registry_uuid: str | None = field(default=None, kw_only=True)
-
-    @abstractmethod
-    def is_model(self, name: str) -> bool:
-        pass
-
-    @abstractmethod
-    def get_registry(self) -> ModelRegistry | None:
-        pass
-
-
-@dataclass
-class Repo:
-    repo_name: str = field(default="", init=False)
-    created_timestamp: str = field(default_factory=datetime.now().isoformat, init=False)
-    modified_timestamp: str = field(
-        default_factory=datetime.now().isoformat, init=False
-    )
 
 
 @dataclass

--- a/mlox/secret_manager.py
+++ b/mlox/secret_manager.py
@@ -8,8 +8,8 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, cast
 from dataclasses import dataclass, field
 
-from mlox.infra import Infrastructure
 from mlox.server import AbstractServer
+from mlox.service import AbstractSecretManagerService
 import importlib
 from mlox.utils import (
     _get_encryption_key,
@@ -55,13 +55,6 @@ class AbstractSecretManager(ABC):
     @abstractmethod
     def get_access_secrets(self) -> Dict[str, Any] | None:
         """Get MLOX access information from the secret manager."""
-        pass
-
-
-@dataclass
-class AbstractSecretManagerService(ABC):
-    @abstractmethod
-    def get_secret_manager(self, infra: Infrastructure) -> AbstractSecretManager:
         pass
 
 

--- a/mlox/service.py
+++ b/mlox/service.py
@@ -22,13 +22,104 @@ import csv
 import json
 import uuid
 import logging
+from datetime import datetime
 from abc import ABC, abstractmethod
-from typing import Dict, Literal, Optional, Protocol
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, Protocol
 from dataclasses import dataclass, field, asdict
 
 from mlox.executors import UbuntuTaskExecutor
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from mlox.infra import Infrastructure
+    from mlox.secret_manager import AbstractSecretManager
+
+
+class ServiceCapability(StrEnum):
+    """User-facing service capabilities advertised by service configs/classes."""
+
+    SECRET_MANAGER = "secret_manager"
+    REPOSITORY = "repository"
+    MODEL_REGISTRY = "model_registry"
+    MODEL_SERVER = "model_server"
+    OBSERVABILITY = "observability"
+    DATA_WAREHOUSE = "data_warehouse"
+    OBJECT_STORAGE = "object_storage"
+    SPREADSHEET = "spreadsheet"
+    DATABASE = "database"
+    VECTOR_DATABASE = "vector_database"
+    CACHE = "cache"
+    MESSAGE_BROKER = "message_broker"
+    WORKFLOW_ORCHESTRATOR = "workflow_orchestrator"
+    FEATURE_STORE = "feature_store"
+    CONTAINER_REGISTRY = "container_registry"
+    DEPLOYMENT = "deployment"
+    LLM = "llm"
+    DASHBOARD = "dashboard"
+
+
+class AbstractSecretManagerService(ABC):
+    """Service capability mixin for services that provide a secret manager client."""
+
+    capabilities: ClassVar[set[ServiceCapability]] = {ServiceCapability.SECRET_MANAGER}
+
+    @abstractmethod
+    def get_secret_manager(
+        self, infra: "Infrastructure"
+    ) -> "AbstractSecretManager":
+        """Return an AbstractSecretManager client for this service."""
+        pass
+
+
+@dataclass
+class AbstractRepositoryService(ABC):
+    """Service capability mixin for repository provider services."""
+
+    capabilities: ClassVar[set[ServiceCapability]] = {ServiceCapability.REPOSITORY}
+    repo_name: str = field(default="", init=False)
+    created_timestamp: str = field(default_factory=datetime.now().isoformat, init=False)
+    modified_timestamp: str = field(default_factory=datetime.now().isoformat, init=False)
+
+    @abstractmethod
+    def get_url(self) -> str:
+        pass
+
+    @abstractmethod
+    def git_clone(self, conn) -> None:
+        pass
+
+    @abstractmethod
+    def git_pull(self, conn) -> None:
+        pass
+
+
+@dataclass
+class AbstractModelRegistryService(ABC):
+    """Service capability mixin for model registry services."""
+
+    capabilities: ClassVar[set[ServiceCapability]] = {ServiceCapability.MODEL_REGISTRY}
+
+    @abstractmethod
+    def list_models(self, filter: str | None = None) -> List[Dict[str, Any]]:
+        pass
+
+
+@dataclass
+class AbstractModelServerService(ABC):
+    """Service capability mixin for model-serving services."""
+
+    capabilities: ClassVar[set[ServiceCapability]] = {ServiceCapability.MODEL_SERVER}
+    registry_uuid: str | None = field(default=None, kw_only=True)
+
+    @abstractmethod
+    def is_model(self, name: str) -> bool:
+        pass
+
+    @abstractmethod
+    def get_registry(self) -> AbstractModelRegistryService | None:
+        pass
 
 
 class ServiceLookup(Protocol):

--- a/mlox/services/airflow/docker.py
+++ b/mlox/services/airflow/docker.py
@@ -24,7 +24,7 @@ import urllib.request
 from typing import Dict
 from dataclasses import dataclass, field
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 from mlox.utils import generate_password
 
 
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class AirflowDockerService(AbstractService):
+    capabilities = {ServiceCapability.WORKFLOW_ORCHESTRATOR}
     path_dags: str
     path_output: str
     ui_user: str

--- a/mlox/services/airflow/mlox.2.9.2.yaml
+++ b/mlox/services/airflow/mlox.2.9.2.yaml
@@ -25,6 +25,11 @@ groups:
   etl: null
   backend:
     docker: null
+capabilities:
+  service:
+  - workflow_orchestrator
+  backend:
+  - docker
 ports:
   web_ui: 1099
 build:

--- a/mlox/services/airflow/mlox.3.1.3.yaml
+++ b/mlox/services/airflow/mlox.3.1.3.yaml
@@ -25,6 +25,11 @@ groups:
   etl: null
   backend:
     docker: null
+capabilities:
+  service:
+  - workflow_orchestrator
+  backend:
+  - docker
 ports:
   web_ui: 1099
 build:

--- a/mlox/services/feast/docker.py
+++ b/mlox/services/feast/docker.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, cast
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 from mlox.services.redis.docker import RedisDockerService
 from mlox.services.postgres.docker import PostgresDockerService
 
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class FeastDockerService(AbstractService):
+    capabilities = {ServiceCapability.FEATURE_STORE}
     """Deploy the Feast registry while reusing remote online/offline stores."""
 
     dockerfile: str

--- a/mlox/services/feast/mlox.feast.yaml
+++ b/mlox/services/feast/mlox.feast.yaml
@@ -35,6 +35,11 @@ groups:
   feature-store: null
   backend:
     docker: null
+capabilities:
+  service:
+  - feature_store
+  backend:
+  - docker
 ports:
   registry: 6564
 build:

--- a/mlox/services/gcp/bq_service.py
+++ b/mlox/services/gcp/bq_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Dict, cast
 
 from mlox.secret_manager import AbstractSecretManagerService
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 from mlox.infra import Infrastructure
 from mlox.services.gcp.bigquery import BigQuery
 
@@ -18,6 +18,7 @@ logging.basicConfig(
 
 @dataclass
 class GCPBigQueryService(AbstractService):
+    capabilities = {ServiceCapability.DATA_WAREHOUSE}
     secret_name: str
     secret_manager_uuid: str
 

--- a/mlox/services/gcp/mlox.gcp.bigquery.yaml
+++ b/mlox/services/gcp/mlox.gcp.bigquery.yaml
@@ -37,6 +37,11 @@ groups:
     docker: null
     native: null
     connector: null
+capabilities:
+  service:
+  - data_warehouse
+  backend:
+  - connector
 build:
   class_name: mlox.services.gcp.bq_service.GCPBigQueryService
   params:

--- a/mlox/services/gcp/mlox.gcp.secrets.yaml
+++ b/mlox/services/gcp/mlox.gcp.secrets.yaml
@@ -36,6 +36,11 @@ groups:
     docker: null
     native: null
     connector: null
+capabilities:
+  service:
+  - secret_manager
+  backend:
+  - connector
 build:
   class_name: mlox.services.gcp.secret_service.GCPSecretService
   params:

--- a/mlox/services/gcp/mlox.gcp.sheets.yaml
+++ b/mlox/services/gcp/mlox.gcp.sheets.yaml
@@ -12,7 +12,7 @@ description: "Google Spreadsheets is a secure and scalable service for managing 
   \ data exchange and collaborative workflows.\n"
 links:
   project: https://workspace.google.com/intl/en_au/products/sheets/
-  news: "https://workspace.google.com/i\xDFntl/en_au/products/sheets/"
+  news: https://workspace.google.com/ißntl/en_au/products/sheets/
   security: https://workspace.google.com/intl/en_au/products/sheets/
   documentation: https://workspace.google.com/intl/en_au/products/sheets/
   changelog: https://workspace.google.com/intl/en_au/products/sheets/
@@ -31,6 +31,11 @@ groups:
     docker: null
     native: null
     connector: null
+capabilities:
+  service:
+  - spreadsheet
+  backend:
+  - connector
 build:
   class_name: mlox.services.gcp.sheet_service.GCPSpreadsheetsService
   params:

--- a/mlox/services/gcp/mlox.gcp.storage.yaml
+++ b/mlox/services/gcp/mlox.gcp.storage.yaml
@@ -36,6 +36,11 @@ groups:
     docker: null
     native: null
     connector: null
+capabilities:
+  service:
+  - object_storage
+  backend:
+  - connector
 build:
   class_name: mlox.services.gcp.storage_service.GCPStorageService
   params:

--- a/mlox/services/gcp/sheet_service.py
+++ b/mlox/services/gcp/sheet_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Dict, cast
 
 from mlox.secret_manager import AbstractSecretManagerService
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 from mlox.infra import Infrastructure
 from mlox.services.gcp.gsheet import GCPSheets
 
@@ -19,6 +19,7 @@ logging.basicConfig(
 
 @dataclass
 class GCPSpreadsheetsService(AbstractService):
+    capabilities = {ServiceCapability.SPREADSHEET}
     secret_name: str
     secret_manager_uuid: str
 

--- a/mlox/services/gcp/storage_service.py
+++ b/mlox/services/gcp/storage_service.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Dict, cast
 
 from mlox.secret_manager import AbstractSecretManagerService
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 from mlox.infra import Infrastructure
 from mlox.services.gcp.cloud_storage import GCPStorage
 
@@ -18,6 +18,7 @@ logging.basicConfig(
 
 @dataclass
 class GCPStorageService(AbstractService):
+    capabilities = {ServiceCapability.OBJECT_STORAGE}
     secret_name: str
     secret_manager_uuid: str
 

--- a/mlox/services/github/mlox.github.yaml
+++ b/mlox/services/github/mlox.github.yaml
@@ -23,6 +23,13 @@ groups:
     kubernetes: null
     docker: null
     native: null
+capabilities:
+  service:
+  - repository
+  backend:
+  - kubernetes
+  - docker
+  - native
 build:
   class_name: mlox.services.github.service.GithubRepoService
   params:

--- a/mlox/services/influx/docker.py
+++ b/mlox/services/influx/docker.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 
 # Configure logging (optional, but recommended)
@@ -32,6 +32,7 @@ logging.basicConfig(
 
 @dataclass
 class InfluxDockerService(AbstractService):
+    capabilities = {ServiceCapability.DATABASE}
     user: str
     pw: str
     port: str | int

--- a/mlox/services/influx/mlox.influx.1.11.8.yaml
+++ b/mlox/services/influx/mlox.influx.1.11.8.yaml
@@ -26,6 +26,11 @@ groups:
     nosql: null
   backend:
     docker: null
+capabilities:
+  service:
+  - database
+  backend:
+  - docker
 ports:
   web_ui: 8086
 build:

--- a/mlox/services/k8s_dashboard/k8s.py
+++ b/mlox/services/k8s_dashboard/k8s.py
@@ -2,13 +2,14 @@ import logging
 from dataclasses import dataclass
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class K8sDashboardService(AbstractService):
+    capabilities = {ServiceCapability.DASHBOARD}
     namespace: str = "kubernetes-dashboard"
     release_name: str = "dashboard"
 

--- a/mlox/services/k8s_dashboard/mlox.k8s_dashboard.yaml
+++ b/mlox/services/k8s_dashboard/mlox.k8s_dashboard.yaml
@@ -26,6 +26,11 @@ groups:
   dashboard: null
   backend:
     kubernetes: null
+capabilities:
+  service:
+  - dashboard
+  backend:
+  - kubernetes
 ports:
   web_ui: 5432
 build:

--- a/mlox/services/k8s_headlamp/k8s.py
+++ b/mlox/services/k8s_headlamp/k8s.py
@@ -3,13 +3,14 @@ from typing import Dict
 from dataclasses import dataclass, field
 
 from mlox.executors import TaskGroup
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class K8sHeadlampService(AbstractService):
+    capabilities = {ServiceCapability.DASHBOARD}
     namespace: str = "kube-system"
     service_name: str = "my-headlamp"
     kubeconfig: str = field(default="/etc/rancher/k3s/k3s.yaml", init=False)

--- a/mlox/services/k8s_headlamp/mlox.headlamp.yaml
+++ b/mlox/services/k8s_headlamp/mlox.headlamp.yaml
@@ -24,6 +24,11 @@ groups:
   dashboard: null
   backend:
     kubernetes: null
+capabilities:
+  service:
+  - dashboard
+  backend:
+  - kubernetes
 build:
   class_name: mlox.services.k8s_headlamp.k8s.K8sHeadlampService
   params:

--- a/mlox/services/kafka/docker.py
+++ b/mlox/services/kafka/docker.py
@@ -20,7 +20,7 @@ import secrets
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 
 
@@ -41,6 +41,7 @@ def _generate_cluster_id() -> str:
 
 @dataclass
 class KafkaDockerService(AbstractService):
+    capabilities = {ServiceCapability.MESSAGE_BROKER}
     """Docker based deployment for a single-node Kafka broker."""
 
     ssl_password: str

--- a/mlox/services/kafka/mlox.kafka.3.7.0.yaml
+++ b/mlox/services/kafka/mlox.kafka.3.7.0.yaml
@@ -30,6 +30,11 @@ groups:
   streaming: null
   backend:
     docker: null
+capabilities:
+  service:
+  - message_broker
+  backend:
+  - docker
 ports:
   service: 9094
 build:

--- a/mlox/services/kafka/mlox.kafka.4.1.0.yaml
+++ b/mlox/services/kafka/mlox.kafka.4.1.0.yaml
@@ -30,6 +30,11 @@ groups:
   streaming: null
   backend:
     docker: null
+capabilities:
+  service:
+  - message_broker
+  backend:
+  - docker
 ports:
   service: 9094
 build:

--- a/mlox/services/kubeapps/k8s.py
+++ b/mlox/services/kubeapps/k8s.py
@@ -4,13 +4,14 @@ from dataclasses import dataclass
 from typing import Dict
 
 from mlox.executors import TaskGroup
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class KubeAppsService(AbstractService):
+    capabilities = {ServiceCapability.DASHBOARD}
     namespace: str = "kubeapps"
     kubeconfig: str = "/etc/rancher/k3s/k3s.yaml"
     release_name: str = "kubeapps"

--- a/mlox/services/kubeapps/mlox.kubeapps.yaml
+++ b/mlox/services/kubeapps/mlox.kubeapps.yaml
@@ -3,11 +3,13 @@ name: KubeApps
 version: 3.0.0
 maintainer: SAP SE
 description_short: KubeApps is a web-based UI for managing Kubernetes applications.
-description: "KubeApps is a web-based UI for managing Kubernetes applications. It\
-  \ provides a user-friendly interface to browse, deploy, upgrade, and delete Helm\
-  \ chart applications running on Kubernetes clusters. This MLOX service installs\
-  \ the SAP-maintained Kubeapps fork from the GHCR OCI Helm chart after the original\
-  \ upstream project was deprecated and archived.\n"
+description: 'KubeApps is a web-based UI for managing Kubernetes applications. It
+  provides a user-friendly interface to browse, deploy, upgrade, and delete Helm chart
+  applications running on Kubernetes clusters. This MLOX service installs the SAP-maintained
+  Kubeapps fork from the GHCR OCI Helm chart after the original upstream project was
+  deprecated and archived.
+
+  '
 links:
   project: https://github.com/SAP/kubeapps
   news: https://github.com/SAP/kubeapps/releases
@@ -23,6 +25,11 @@ groups:
   app-management: null
   backend:
     kubernetes: null
+capabilities:
+  service:
+  - dashboard
+  backend:
+  - kubernetes
 ports:
   web_ui: 30080
 build:

--- a/mlox/services/litellm/docker.py
+++ b/mlox/services/litellm/docker.py
@@ -21,7 +21,11 @@ from typing import Dict, Any, List
 
 import yaml
 
-from mlox.service import AbstractService
+from mlox.service import (
+    AbstractModelServerService,
+    AbstractService,
+    ServiceCapability,
+)
 
 
 # Configure logging (optional, but recommended)
@@ -33,7 +37,8 @@ logging.basicConfig(
 
 
 @dataclass
-class LiteLLMDockerService(AbstractService):
+class LiteLLMDockerService(AbstractService, AbstractModelServerService):
+    capabilities = {ServiceCapability.LLM, ServiceCapability.MODEL_SERVER}
     ollama_script: str
     litellm_config: str
     ui_user: str
@@ -145,6 +150,12 @@ class LiteLLMDockerService(AbstractService):
             self.state = "unknown"
 
         return {"status": status, "services": services}
+
+    def is_model(self, name: str) -> bool:
+        return name in self.ollama_models
+
+    def get_registry(self):
+        return None
 
     def get_secrets(self) -> Dict[str, Dict]:
         secrets: Dict[str, Dict] = {}

--- a/mlox/services/litellm/mlox.litellm.1.77.7.yaml
+++ b/mlox/services/litellm/mlox.litellm.1.77.7.yaml
@@ -25,6 +25,12 @@ groups:
   service: null
   backend:
     docker: null
+capabilities:
+  service:
+  - llm
+  - model_server
+  backend:
+  - docker
 ports:
   web_ui: 5222
 build:

--- a/mlox/services/milvus/docker.py
+++ b/mlox/services/milvus/docker.py
@@ -21,7 +21,7 @@ import base64
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 
 # Configure logging (optional, but recommended)
@@ -41,6 +41,7 @@ def _generate_htpasswd_sha1(user: str, password: str) -> str:
 
 @dataclass
 class MilvusDockerService(AbstractService):
+    capabilities = {ServiceCapability.VECTOR_DATABASE}
     config: str
     user: str
     pw: str

--- a/mlox/services/milvus/mlox.milvus.2.5.yaml
+++ b/mlox/services/milvus/mlox.milvus.2.5.yaml
@@ -25,6 +25,11 @@ groups:
     vector: null
   backend:
     docker: null
+capabilities:
+  service:
+  - vector_database
+  backend:
+  - docker
 ports:
   service: 19530
 build:

--- a/mlox/services/minio/docker.py
+++ b/mlox/services/minio/docker.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 
 logging.basicConfig(
@@ -31,6 +31,7 @@ logging.basicConfig(
 
 @dataclass
 class MinioDockerService(AbstractService):
+    capabilities = {ServiceCapability.OBJECT_STORAGE}
     root_user: str
     root_password: str
     api_port: str | int

--- a/mlox/services/minio/mlox.minio.RELEASE.2025-07-23.yaml
+++ b/mlox/services/minio/mlox.minio.RELEASE.2025-07-23.yaml
@@ -27,6 +27,11 @@ groups:
   storage: null
   backend:
     docker: null
+capabilities:
+  service:
+  - object_storage
+  backend:
+  - docker
 ports:
   api: 9000
   console: 9001

--- a/mlox/services/mlflow/mlox.mlflow.2.22.0.yaml
+++ b/mlox/services/mlflow/mlox.mlflow.2.22.0.yaml
@@ -26,6 +26,11 @@ groups:
   experiment-tracking: null
   backend:
     docker: null
+capabilities:
+  service:
+  - model_registry
+  backend:
+  - docker
 ports:
   web_ui: 5432
 build:

--- a/mlox/services/mlflow/mlox.mlflow.3.8.1.yaml
+++ b/mlox/services/mlflow/mlox.mlflow.3.8.1.yaml
@@ -33,6 +33,11 @@ groups:
   experiment-tracking: null
   backend:
     docker: null
+capabilities:
+  service:
+  - model_registry
+  backend:
+  - docker
 ports:
   web_ui: 5432
 build:

--- a/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.yaml
+++ b/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.yaml
@@ -3,10 +3,10 @@ name: MLFlow Gateway
 version: 3.8.1
 maintainer: Your Name
 description_short: Lightweight multi-model HTTP gateway for MLflow registry models.
-description: 'Provides a simple authenticated HTTPS endpoint that loads MLflow pyfunc
+description: Provides a simple authenticated HTTPS endpoint that loads MLflow pyfunc
   models dynamically from a configured MLflow registry and caches them for repeated
   predictions. It is intended as a flexible lightweight complement to MLServer for
-  exploration, internal tooling, and lower-criticality model access.'
+  exploration, internal tooling, and lower-criticality model access.
 links:
   project: https://mlflow.org/
   news: https://mlflow.org/releases/
@@ -22,6 +22,11 @@ groups:
   model-server: null
   backend:
     docker: null
+capabilities:
+  service:
+  - model_server
+  backend:
+  - docker
 ports:
   rest: 6433
 build:

--- a/mlox/services/mlflow_mlserver/mlox.mlserver.2.22.0.yaml
+++ b/mlox/services/mlflow_mlserver/mlox.mlserver.2.22.0.yaml
@@ -5,8 +5,8 @@ maintainer: Your Name
 description_short: MLServer is an open-source Python library for building production-ready
   asynchronous APIs for machine learning models.
 description: "MLServer aims to provide an easy way to start serving your machine learning\
-  \ models through a REST and gRPC interface, \nfully compliant with KFServing\u2019\
-  s V2 Dataplane spec. MLServer supports multi-model serving, the ability to run inference\
+  \ models through a REST and gRPC interface, \nfully compliant with KFServing’s V2\
+  \ Dataplane spec. MLServer supports multi-model serving, the ability to run inference\
   \ in parallel for vertical scaling across multiple models through a \nsharedpool\
   \ of inference workers, and more. This service uses MLFlow MLServer integration\
   \ to deploy single\nmodels. The version of this service refers to MLFlow.\n"
@@ -25,6 +25,11 @@ groups:
   model-server: null
   backend:
     docker: null
+capabilities:
+  service:
+  - model_server
+  backend:
+  - docker
 ports:
   rest: 6432
 build:

--- a/mlox/services/mlflow_mlserver/mlox.mlserver.3.8.1.k3s.yaml
+++ b/mlox/services/mlflow_mlserver/mlox.mlserver.3.8.1.k3s.yaml
@@ -27,6 +27,11 @@ groups:
   model-server: null
   backend:
     kubernetes: null
+capabilities:
+  service:
+  - model_server
+  backend:
+  - kubernetes
 ports:
   rest: 30432
 build:

--- a/mlox/services/mlflow_mlserver/mlox.mlserver.3.8.1.yaml
+++ b/mlox/services/mlflow_mlserver/mlox.mlserver.3.8.1.yaml
@@ -32,6 +32,11 @@ groups:
   model-server: null
   backend:
     docker: null
+capabilities:
+  service:
+  - model_server
+  backend:
+  - docker
 ports:
   rest: 6432
 build:

--- a/mlox/services/ollama/docker.py
+++ b/mlox/services/ollama/docker.py
@@ -9,13 +9,18 @@ from typing import Dict, List
 from passlib.hash import apr_md5_crypt  # type: ignore
 
 from mlox.executors import TaskGroup
-from mlox.service import AbstractService
+from mlox.service import (
+    AbstractModelServerService,
+    AbstractService,
+    ServiceCapability,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class OllamaDockerService(AbstractService):
+class OllamaDockerService(AbstractService, AbstractModelServerService):
+    capabilities = {ServiceCapability.LLM, ServiceCapability.MODEL_SERVER}
     port: str | int
     user: str = "admin"
     pw: str = "s3cr3t"
@@ -112,6 +117,12 @@ class OllamaDockerService(AbstractService):
             logger.error("Error checking Ollama status: %s", exc)
             self.state = "unknown"
         return {"status": "unknown"}
+
+    def is_model(self, name: str) -> bool:
+        return name in self.ollama_models
+
+    def get_registry(self):
+        return None
 
     def get_secrets(self) -> Dict[str, Dict]:
         return {

--- a/mlox/services/ollama/mlox.ollama.0.23.3.yaml
+++ b/mlox/services/ollama/mlox.ollama.0.23.3.yaml
@@ -3,9 +3,9 @@ name: Ollama
 version: 0.23.3
 maintainer: Your Name
 description_short: Standalone Ollama service with HTTPS and BasicAuth via Traefik.
-description: 'Runs Ollama as an independently managed MLOX service. The native Ollama
+description: Runs Ollama as an independently managed MLOX service. The native Ollama
   HTTP API is kept behind a Traefik reverse proxy that provides HTTPS and BasicAuth,
-  matching the MLServer and MLflow Gateway exposure pattern.'
+  matching the MLServer and MLflow Gateway exposure pattern.
 links:
   project: https://ollama.com/
   news: https://ollama.com/blog
@@ -22,6 +22,12 @@ groups:
   model-server: null
   backend:
     docker: null
+capabilities:
+  service:
+  - llm
+  - model_server
+  backend:
+  - docker
 ports:
   rest: 11434
 build:

--- a/mlox/services/openbao/mlox.openbao.yaml
+++ b/mlox/services/openbao/mlox.openbao.yaml
@@ -6,8 +6,8 @@ description_short: OpenBao provides a Vault-compatible secret management server.
 description: 'OpenBao is an open-source, Vault-compatible secret manager offering
   a secure key-value store
 
-  and policy engine for managing sensitive information. This stack runs OpenBao
-  with integrated Raft storage and mlox-managed initialization/unseal material.
+  and policy engine for managing sensitive information. This stack runs OpenBao with
+  integrated Raft storage and mlox-managed initialization/unseal material.
 
   '
 links:
@@ -22,6 +22,11 @@ groups:
   secret-manager: null
   backend:
     docker: null
+capabilities:
+  service:
+  - secret_manager
+  backend:
+  - docker
 ports:
   api: 8200
 build:

--- a/mlox/services/otel/docker.py
+++ b/mlox/services/otel/docker.py
@@ -22,7 +22,7 @@ from typing import Dict, Any
 from urllib.parse import unquote
 
 from mlox.executors import TaskGroup
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 # Configure logging (optional, but recommended)
 logging.basicConfig(
@@ -34,6 +34,7 @@ logging.basicConfig(
 
 @dataclass
 class OtelDockerService(AbstractService):
+    capabilities = {ServiceCapability.OBSERVABILITY}
     relic_endpoint: str
     relic_key: str
     config: str

--- a/mlox/services/otel/mlox.otel.0.127.0.yaml
+++ b/mlox/services/otel/mlox.otel.0.127.0.yaml
@@ -1,6 +1,6 @@
 id: otel-0.127.0-docker
 name: OpenTelemetry Collector
-version: "0.127.0"
+version: 0.127.0
 maintainer: Your Name
 description_short: OpenTelemetry Collector is a service for collecting and exporting
   telemetry data.
@@ -28,6 +28,11 @@ groups:
   monitor: null
   backend:
     docker: null
+capabilities:
+  service:
+  - observability
+  backend:
+  - docker
 ports:
   grpc: 4317
   http: 4318

--- a/mlox/services/otel/mlox.otel.0.146.1.yaml
+++ b/mlox/services/otel/mlox.otel.0.146.1.yaml
@@ -28,6 +28,11 @@ groups:
   monitor: null
   backend:
     docker: null
+capabilities:
+  service:
+  - observability
+  backend:
+  - docker
 ports:
   grpc: 4317
   http: 4318

--- a/mlox/services/postgres/docker.py
+++ b/mlox/services/postgres/docker.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 
 # Configure logging (optional, but recommended)
@@ -32,6 +32,7 @@ logging.basicConfig(
 
 @dataclass
 class PostgresDockerService(AbstractService):
+    capabilities = {ServiceCapability.DATABASE}
     user: str
     pw: str
     db: str

--- a/mlox/services/postgres/mlox.postgres.16.yaml
+++ b/mlox/services/postgres/mlox.postgres.16.yaml
@@ -26,6 +26,11 @@ groups:
     relational: null
   backend:
     docker: null
+capabilities:
+  service:
+  - database
+  backend:
+  - docker
 ports:
   service: 5432
 build:

--- a/mlox/services/redis/docker.py
+++ b/mlox/services/redis/docker.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 
 # Configure logging (optional, but recommended)
@@ -32,6 +32,7 @@ logging.basicConfig(
 
 @dataclass
 class RedisDockerService(AbstractService):
+    capabilities = {ServiceCapability.CACHE, ServiceCapability.DATABASE}
     pw: str
     port: str | int
     compose_service_names: Dict[str, str] = field(

--- a/mlox/services/redis/mlox.redis.8.yaml
+++ b/mlox/services/redis/mlox.redis.8.yaml
@@ -26,6 +26,12 @@ groups:
     nosql: null
   backend:
     docker: null
+capabilities:
+  service:
+  - cache
+  - database
+  backend:
+  - docker
 ports:
   service: 6379
 build:

--- a/mlox/services/registry/docker.py
+++ b/mlox/services/registry/docker.py
@@ -20,13 +20,14 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict
 
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class RegistryDockerService(AbstractService):
+    capabilities = {ServiceCapability.CONTAINER_REGISTRY}
     """Manage a TLS and basic-auth protected Docker distribution registry."""
 
     username: str

--- a/mlox/services/registry/mlox.registry.3.yaml
+++ b/mlox/services/registry/mlox.registry.3.yaml
@@ -1,13 +1,19 @@
 id: registry-3-docker
 name: Private Registry
-version: "3"
+version: '3'
 maintainer: MLOX Contributors
-description_short: Secure, private Docker distribution registry with TLS and htpasswd auth.
-description: |
-  Deploy a private Docker distribution registry secured with automatically managed
+description_short: Secure, private Docker distribution registry with TLS and htpasswd
+  auth.
+description: 'Deploy a private Docker distribution registry secured with automatically
+  managed
+
   TLS certificates and HTTP basic authentication. Use this stack to host container
+
   images locally for development or to experiment with authenticated registries
+
   without relying on third-party services.
+
+  '
 links:
   project: https://distribution.github.io/distribution/
   documentation: https://distribution.github.io/distribution/about/deploying/
@@ -17,10 +23,15 @@ requirements:
   ram_gb: 1.0
   disk_gb: 5.0
 groups:
-  service:
-  storage:
+  service: null
+  storage: null
   backend:
-    docker:
+    docker: null
+capabilities:
+  service:
+  - container_registry
+  backend:
+  - docker
 ports:
   registry: 5000
 build:

--- a/mlox/services/repo_deploy/mlox.repo_deploy.0.1.yaml
+++ b/mlox/services/repo_deploy/mlox.repo_deploy.0.1.yaml
@@ -23,8 +23,8 @@ groups:
   backend:
     docker: null
 capabilities:
-  server:
-  - docker
+  service:
+  - deployment
   backend:
   - docker
 build:

--- a/mlox/services/repo_deploy/service.py
+++ b/mlox/services/repo_deploy/service.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict
 
 from mlox.execution import TaskGroup
-from mlox.service import AbstractService
+from mlox.service import AbstractService, ServiceCapability
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +16,7 @@ _ENV_TOKEN_PATTERN = re.compile(
 
 @dataclass
 class RepoDeployDockerService(AbstractService):
+    capabilities = {ServiceCapability.DEPLOYMENT}
     repo_uuid: str
     compose_file: str
     env_vars: Dict[str, str] = field(default_factory=dict)

--- a/mlox/services/tsm/mlox.tsm.yaml
+++ b/mlox/services/tsm/mlox.tsm.yaml
@@ -25,6 +25,13 @@ groups:
     kubernetes: null
     docker: null
     native: null
+capabilities:
+  service:
+  - secret_manager
+  backend:
+  - kubernetes
+  - docker
+  - native
 build:
   class_name: mlox.services.tsm.service.TSMService
   params:

--- a/tests/unit/test_service_configs.py
+++ b/tests/unit/test_service_configs.py
@@ -238,3 +238,56 @@ class TestServiceConfig:
         assert configs[0].name == "TestService"
         assert "Error parsing YAML file" in caplog.text
         assert "mlox.invalid.v1.yaml" in caplog.text
+
+
+def test_service_capabilities_fall_back_from_groups(service_config_data):
+    service_config_data["build"] = BuildConfig(**service_config_data["build"])
+    service_config_data["groups"] = {
+        "service": None,
+        "model-registry": None,
+        "backend": {"docker": None},
+    }
+    config = ServiceConfig(**service_config_data)
+
+    assert config.service_capabilities() == {"model_registry"}
+    assert config.backend_capabilities() == {"docker"}
+
+
+def test_service_capability_mismatch_logs_warning(
+    tmp_path, caplog, mock_dummy_modules, service_config_data
+):
+    service_config_data["capabilities"] = {
+        "service": ["repository"],
+        "backend": ["docker"],
+    }
+    create_yaml_file(tmp_path, "dummy", service_config_data)
+
+    caplog.set_level("WARNING")
+    config = load_config(str(tmp_path), "dummy", "mlox.dummy.v1.yaml")
+
+    assert config is not None
+    assert "declares service capabilities not supported" in caplog.text
+    assert "does not implement AbstractRepositoryService" in caplog.text
+
+
+def test_builtin_service_configs_have_matching_explicit_capabilities():
+    from mlox.config import _load_build_class
+    from mlox.service import ServiceCapability
+
+    configs = load_all_service_configs(include_plugins=False)
+    known = {capability.value for capability in ServiceCapability}
+    assert configs
+
+    for config in configs:
+        assert config.capabilities, config.path
+        assert config.service_capabilities(), config.path
+        assert config.backend_capabilities(), config.path
+        assert config.service_capabilities() <= known, config.path
+
+        service_class = _load_build_class(config)
+        assert service_class is not None, config.path
+        class_capabilities = {
+            capability.value if hasattr(capability, "value") else str(capability)
+            for capability in getattr(service_class, "capabilities", set())
+        }
+        assert config.service_capabilities() <= class_capabilities, config.path


### PR DESCRIPTION
### Motivation
- Introduce a service capability model parallel to existing server capabilities so services can explicitly advertise and be validated for supported functionality.
- Provide minimal behavioral mixins for common service roles (secret manager provider, repository, model registry, model server) to support runtime checks and UI behavior.
- Preserve backwards compatibility so existing `groups`-only YAMLs still load and legacy imports (`mlox.infra` and `mlox.secret_manager`) keep working.
- Validate mismatches with warnings (non-fatal) to avoid breaking existing installs while surfacing configuration/class inconsistencies.

### Description
- Add `ServiceCapability` and lightweight service capability mixins in `mlox/service.py` including `AbstractSecretManagerService`, `AbstractRepositoryService`, `AbstractModelRegistryService`, and `AbstractModelServerService`, and small behavioral signatures (`get_secret_manager`, `get_url`/`git_clone`/`git_pull`, `list_models`, `is_model`/`get_registry`).
- Extend `mlox/config.py` to normalize service capability names, derive `service` capabilities from legacy `groups`, and add `_validate_service_config_capabilities` which mirrors the server validation approach but emits warnings instead of failing; server validation is unchanged.
- Preserve compatibility by aliasing the new service mixins into the places consumers expect: `mlox/infra.py` now imports `AbstractModelRegistryService`/`AbstractModelServerService`/`AbstractRepositoryService` as `ModelRegistry`/`ModelServer`/`Repo`, and `mlox/secret_manager.py` now treats `AbstractSecretManagerService` as the provider interface while keeping `AbstractSecretManager` as the concrete client abstraction.
- Update built-in service implementations to advertise class-level `capabilities` (where applicable) and add explicit `capabilities.service` and `capabilities.backend` sections to the YAMLs under `mlox/services/**/mlox*.yaml` while leaving the original `groups` intact for backward compatibility.

### Testing
- Ran `pytest -q tests/unit/test_service_configs.py` and confirmed the new parsing, group fallback, and validation-warning tests passed.
- Ran targeted tests `pytest -q tests/unit/test_secret_manager_unit.py tests/unit/test_tsm.py tests/unit/services/test_repo_deploy_service.py tests/unit/services/test_kubeapps_service.py` and observed they passed.
- Ran the full unit suite `pytest -q tests/unit` and observed all tests passed (`306 passed`) with a small number of unrelated warnings (`5 warnings`).
- Verified built-in service YAMLs load and that capability mismatches log warnings rather than preventing config loading.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed54e54248322b6feb3826e73300b)