### PR TITLE
OpenBao: add mlox-managed policies, userpass UI, and scoped client tokens; API, Docker and UI updates

### DIFF
--- a/mlox/services/openbao/README.md
+++ b/mlox/services/openbao/README.md
@@ -20,6 +20,7 @@ The mlox OpenBao stack now uses:
 - Persistent host bind mounts for `data`, `logs`, config, and TLS material.
 - mlox-managed initialization, unseal keys, and root token storage.
 - KV v2 enabled at the configured mount path.
+- mlox-scoped policies, userpass UI login, and renewable client token.
 - File audit logging at `/openbao/logs/audit.log`.
 
 The Docker compose stack intentionally exposes OpenBao directly over HTTPS. It
@@ -64,7 +65,10 @@ container-local `bao` CLI. It then performs bootstrap:
 2. mlox stores the returned root token and unseal key in the service state.
 3. If OpenBao is sealed, mlox submits stored unseal keys.
 4. mlox ensures KV v2 exists at `mount_path`.
-5. mlox enables file audit logging.
+5. mlox writes least-privilege mlox policies.
+6. mlox enables userpass and creates UI login credentials.
+7. mlox creates a renewable scoped client token for secret-manager access.
+8. mlox enables file audit logging.
 
 The default bootstrap uses one key share and a threshold of one:
 
@@ -84,15 +88,16 @@ The OpenBao settings panel shows:
 
 - initialization status
 - seal status
-- masked root token
-- optional full root token reveal
-- unseal key count
-- optional unseal key reveal
+- userpass UI login credentials
+- scoped mlox client token status
+- token renewal and rotation actions
+- emergency-only root token reveal
+- unseal key count and optional emergency reveal
 - an `Unseal` button when OpenBao is sealed
 - the KV secret list when OpenBao is initialized and unsealed
 
-Use `Show full root token` when you need to log into the OpenBao browser UI.
-The namespace is `root`.
+Use the generated userpass credentials for the OpenBao browser UI. Use the root
+token only for recovery or bootstrap administration. The namespace is `root`.
 
 Secrets can be added, listed, and read directly from the mlox UI. The client uses
 KV v2 paths, so a secret named `example` is written to:
@@ -122,10 +127,13 @@ the client machine.
 Login with:
 
 ```text
-Method: Token
-Token: <root token shown in mlox settings>
+Method: userpass
+Username: <mlox admin username shown in settings>
+Password: <mlox admin password shown in settings>
 Namespace: root
 ```
+
+Root token login remains available only as emergency recovery material.
 
 ## Seal And Unseal
 
@@ -171,8 +179,8 @@ and the bootstrap call is container-local. mlox clients also default
 ## Operational Notes
 
 - Keep the root token and unseal key backed up outside mlox.
-- Rotate away from the root token for day-to-day OpenBao administration when
-  adding policy and token management.
+- Use the generated userpass credentials and scoped client token for day-to-day
+  access instead of the root token.
 - Do not use teardown unless deleting the OpenBao data is intended.
 - Future production hardening can add HA Raft peers, KMS auto-unseal, trusted
   certificates, and least-privilege OpenBao policies.

--- a/mlox/services/openbao/README.md
+++ b/mlox/services/openbao/README.md
@@ -55,6 +55,8 @@ The generated OpenBao config includes:
 - `cluster_addr = "http://openbao:8201"`
 - `ui = true`
 - `disable_mlock = true`
+- file audit logging at `/openbao/logs/audit.log` via declarative
+  `audit "file" "file"` configuration
 
 ## Bootstrap Flow
 
@@ -68,7 +70,9 @@ container-local `bao` CLI. It then performs bootstrap:
 5. mlox writes least-privilege mlox policies.
 6. mlox enables userpass and creates UI login credentials.
 7. mlox creates a renewable scoped client token for secret-manager access.
-8. mlox enables file audit logging.
+
+File audit logging is configured before startup in `openbao.hcl`. OpenBao no
+longer allows normal API-created audit devices in this runtime mode.
 
 The default bootstrap uses one key share and a threshold of one:
 
@@ -98,6 +102,12 @@ The OpenBao settings panel shows:
 
 Use the generated userpass credentials for the OpenBao browser UI. Use the root
 token only for recovery or bootstrap administration. The namespace is `root`.
+
+The downloadable secret-manager keyfile contains only a scoped mlox API token
+and connection metadata. It does not contain the root token, unseal keys, or UI
+password. For OpenBao, keyfiles are generated for named applications. mlox stores
+only each application's token accessor and metadata, so the root-backed UI can
+renew or revoke that application's credential without storing the token value.
 
 Secrets can be added, listed, and read directly from the mlox UI. The client uses
 KV v2 paths, so a secret named `example` is written to:
@@ -181,6 +191,12 @@ and the bootstrap call is container-local. mlox clients also default
 - Keep the root token and unseal key backed up outside mlox.
 - Use the generated userpass credentials and scoped client token for day-to-day
   access instead of the root token.
+- Application keyfile tokens are periodic renewable tokens. They can keep
+  running indefinitely if they are renewed before each selected period expires.
+- If a keyfile token expires, API calls made with that keyfile fail with
+  OpenBao's token-expired/permission error. Rotate and download a new keyfile.
+- Rotating the service token does not update already downloaded keyfiles because
+  each keyfile contains its own token string.
 - Do not use teardown unless deleting the OpenBao data is intended.
 - Future production hardening can add HA Raft peers, KMS auto-unseal, trusted
   certificates, and least-privilege OpenBao policies.

--- a/mlox/services/openbao/USAGE.md
+++ b/mlox/services/openbao/USAGE.md
@@ -1,0 +1,45 @@
+# OpenBao Usage in mlox
+
+OpenBao is the mlox secret-manager backend for shared application and
+infrastructure secrets.
+
+## Bootstrap
+
+When the service starts, mlox initializes and unseals OpenBao, enables KV v2 at
+`secret/` by default, writes mlox policies, enables `userpass`, creates a UI
+login, and creates a renewable scoped client token.
+
+## Normal access
+
+Use the OpenBao UI with:
+
+- Method: `userpass`
+- Username/password: shown in the mlox OpenBao settings
+- Namespace: `root`
+
+Do not use the root token for normal UI access. Root and unseal material are
+recovery-only values.
+
+## mlox secret access
+
+mlox stores and reads secrets through the scoped client token. The exported
+service secret contains only:
+
+- OpenBao address
+- scoped client token
+- KV mount path
+- TLS verification setting
+- token renewal metadata
+
+It does not export the root token, unseal keys, or UI password.
+
+## External clients
+
+A slim client only needs the OpenBao address, scoped token, mount path, and TLS
+preference. It does not need the mlox infrastructure model.
+
+Secrets are stored in KV v2 paths under:
+
+```text
+/<mount_path>/data/<secret-name>
+```

--- a/mlox/services/openbao/USAGE.md
+++ b/mlox/services/openbao/USAGE.md
@@ -1,4 +1,4 @@
-# OpenBao Usage in mlox
+# OpenBao Usage
 
 OpenBao is the mlox secret-manager backend for shared application and
 infrastructure secrets.
@@ -9,7 +9,7 @@ When the service starts, mlox initializes and unseals OpenBao, enables KV v2 at
 `secret/` by default, writes mlox policies, enables `userpass`, creates a UI
 login, and creates a renewable scoped client token.
 
-## Normal access
+## Browser access
 
 Use the OpenBao UI with:
 
@@ -20,7 +20,7 @@ Use the OpenBao UI with:
 Do not use the root token for normal UI access. Root and unseal material are
 recovery-only values.
 
-## mlox secret access
+## mlox access
 
 mlox stores and reads secrets through the scoped client token. The exported
 service secret contains only:
@@ -33,6 +33,26 @@ service secret contains only:
 
 It does not export the root token, unseal keys, or UI password.
 
+If the mlox service token expires, rotate it in the Access tab. Rotation creates
+and saves a fresh scoped token using the root-backed admin path.
+
+## Application credentials
+
+Use one named credential per application, for example `training-worker` or
+`feature-store-sync`.
+
+- Add the application in the Applications tab and choose a renewal period.
+- Use `Renew` before the selected period expires.
+- Use `Revoke` when an application should lose access.
+- Use `Rotate keyfile` only when the application needs a new downloadable token.
+
+mlox stores the token accessor and metadata, not the token value. The accessor
+allows root-backed lookup, renewal, and revocation without granting secret
+access.
+
+Application credentials are periodic renewable tokens. They can run indefinitely
+only if the application renews them before each selected period expires.
+
 ## External clients
 
 A slim client only needs the OpenBao address, scoped token, mount path, and TLS
@@ -43,3 +63,6 @@ Secrets are stored in KV v2 paths under:
 ```text
 /<mount_path>/data/<secret-name>
 ```
+
+If a downloaded application token expires, renew it from the application before
+expiry or rotate and download a new keyfile from mlox.

--- a/mlox/services/openbao/client.py
+++ b/mlox/services/openbao/client.py
@@ -47,8 +47,15 @@ class OpenBaoSecretManager(AbstractSecretManager):
         data: Dict[str, Any] | None = None,
         params: Dict[str, Any] | None = None,
         expected_status: tuple[int, ...] = (200, 204),
+        token: str | None = None,
+        include_token: bool = True,
     ) -> Dict[str, Any]:
-        """Execute an HTTP request against the OpenBao API."""
+        """Execute an HTTP request against the OpenBao API.
+
+        The client is self-contained: every operation only needs an OpenBao
+        address, token, mount path, and TLS preference. Calls such as userpass
+        login can opt out of the token header with ``include_token=False``.
+        """
 
         url = f"{self.address}{path}"
         if params:
@@ -57,7 +64,10 @@ class OpenBaoSecretManager(AbstractSecretManager):
                 url = f"{url}?{query}"
 
         payload_bytes = None
-        headers = {"X-Vault-Token": self.token}
+        headers: Dict[str, str] = {}
+        selected_token = self.token if token is None else token
+        if include_token and selected_token:
+            headers["X-Vault-Token"] = selected_token
         if data is not None:
             payload_bytes = json.dumps(data).encode("utf-8")
             headers["Content-Type"] = "application/json"
@@ -163,6 +173,118 @@ class OpenBaoSecretManager(AbstractSecretManager):
         errors = response.get("errors", [])
         if errors and not any("path is already in use" in str(err) for err in errors):
             raise RuntimeError(f"Could not enable OpenBao KV v2 mount {mount}: {errors}")
+
+    def list_mounts(self) -> Dict[str, Any]:
+        """Return enabled secrets engines keyed by mount path."""
+
+        return self._request("GET", "/v1/sys/mounts").get("data", {})
+
+    def ensure_kv_v2(self, mount_path: str | None = None) -> None:
+        """Ensure a KV v2 secrets engine exists at ``mount_path``."""
+
+        mount = (mount_path or self.mount_path).strip("/") or self.mount_path
+        mounts = self.list_mounts()
+        mount_key = f"{mount}/"
+        existing = mounts.get(mount_key) or mounts.get(mount)
+        if existing:
+            options = existing.get("options", {}) if isinstance(existing, dict) else {}
+            if existing.get("type") == "kv" and str(options.get("version")) == "2":
+                return
+        self.enable_kv_v2(mount)
+
+    def write_policy(self, name: str, policy: str) -> None:
+        """Create or update an OpenBao policy."""
+
+        self._request(
+            "POST",
+            f"/v1/sys/policy/{name}",
+            data={"policy": policy},
+            expected_status=(200, 204),
+        )
+
+    def read_policy(self, name: str) -> Dict[str, Any] | None:
+        """Read a policy or return ``None`` if it does not exist."""
+
+        try:
+            return self._request("GET", f"/v1/sys/policy/{name}")
+        except HTTPError as exc:
+            if exc.code == 404:
+                return None
+            raise
+
+    def list_auth_methods(self) -> Dict[str, Any]:
+        """Return enabled auth methods keyed by mount path."""
+
+        return self._request("GET", "/v1/sys/auth").get("data", {})
+
+    def enable_auth_method(self, path: str, auth_type: str) -> None:
+        """Enable an auth method if it is not already enabled."""
+
+        mount = path.strip("/")
+        response = self._request(
+            "POST",
+            f"/v1/sys/auth/{mount}",
+            data={"type": auth_type},
+            expected_status=(200, 204, 400),
+        )
+        errors = response.get("errors", [])
+        if errors and not any("path is already in use" in str(err) for err in errors):
+            raise RuntimeError(
+                f"Could not enable OpenBao auth method {auth_type} at {mount}: {errors}"
+            )
+
+    def ensure_userpass_auth(self, path: str = "userpass") -> None:
+        """Ensure userpass auth is enabled at ``path``."""
+
+        mount = path.strip("/") or "userpass"
+        auth_methods = self.list_auth_methods()
+        existing = auth_methods.get(f"{mount}/") or auth_methods.get(mount)
+        if isinstance(existing, dict) and existing.get("type") == "userpass":
+            return
+        self.enable_auth_method(mount, "userpass")
+
+    def create_or_update_userpass_user(
+        self,
+        username: str,
+        password: str,
+        *,
+        policies: list[str],
+        ttl: str | int | None = "8h",
+        max_ttl: str | int | None = "24h",
+        path: str = "userpass",
+    ) -> None:
+        """Create or update a userpass user for UI login."""
+
+        payload: Dict[str, Any] = {
+            "password": password,
+            "token_policies": policies,
+        }
+        if ttl is not None:
+            payload["token_ttl"] = self._stringify_duration(ttl)
+        if max_ttl is not None:
+            payload["token_max_ttl"] = self._stringify_duration(max_ttl)
+        self._request(
+            "POST",
+            f"/v1/auth/{path.strip('/')}/users/{username}",
+            data=payload,
+            expected_status=(200, 204),
+        )
+
+    def login_userpass(
+        self, username: str, password: str, *, path: str = "userpass"
+    ) -> Dict[str, Any]:
+        """Authenticate with userpass and return the OpenBao ``auth`` block."""
+
+        response = self._request(
+            "POST",
+            f"/v1/auth/{path.strip('/')}/login/{username}",
+            data={"password": password},
+            include_token=False,
+        )
+        auth = response.get("auth", {})
+        if not auth.get("client_token"):
+            raise RuntimeError("OpenBao userpass login did not return a client token.")
+        return auth
 
     def enable_file_audit(self, path: str = "/openbao/logs/audit.log") -> None:
         response = self._request(
@@ -294,6 +416,46 @@ class OpenBaoSecretManager(AbstractSecretManager):
         client_token = auth.get("client_token")
         if not client_token:
             raise RuntimeError("OpenBao did not return a client token.")
+        return auth
+
+    def lookup_self(self) -> Dict[str, Any]:
+        """Lookup the current token and return the OpenBao data block."""
+
+        return self._request("GET", "/v1/auth/token/lookup-self").get("data", {})
+
+    def lookup_token(self, token: str) -> Dict[str, Any]:
+        """Lookup an arbitrary token using the current token's privileges."""
+
+        return self._request(
+            "POST", "/v1/auth/token/lookup", data={"token": token}
+        ).get("data", {})
+
+    def renew_self(self, increment: str | int | None = None) -> Dict[str, Any]:
+        """Renew the current token and return the OpenBao auth block."""
+
+        payload: Dict[str, Any] = {}
+        if increment is not None:
+            payload["increment"] = self._stringify_duration(increment)
+        response = self._request(
+            "POST", "/v1/auth/token/renew-self", data=payload
+        )
+        auth = response.get("auth", {})
+        if not auth:
+            raise RuntimeError("OpenBao did not return token renewal information.")
+        return auth
+
+    def renew_token(
+        self, token: str, increment: str | int | None = None
+    ) -> Dict[str, Any]:
+        """Renew an arbitrary token using the current token's privileges."""
+
+        payload: Dict[str, Any] = {"token": token}
+        if increment is not None:
+            payload["increment"] = self._stringify_duration(increment)
+        response = self._request("POST", "/v1/auth/token/renew", data=payload)
+        auth = response.get("auth", {})
+        if not auth:
+            raise RuntimeError("OpenBao did not return token renewal information.")
         return auth
 
     def get_access_secrets(self) -> Dict[str, Any] | None:

--- a/mlox/services/openbao/client.py
+++ b/mlox/services/openbao/client.py
@@ -296,6 +296,7 @@ class OpenBaoSecretManager(AbstractSecretManager):
         errors = response.get("errors", [])
         if errors and not any(
             "path is already in use" in str(err) or "already exists" in str(err)
+            or "declarative, config-based audit device management" in str(err)
             for err in errors
         ):
             raise RuntimeError(f"Could not enable OpenBao file audit: {errors}")
@@ -374,7 +375,7 @@ class OpenBaoSecretManager(AbstractSecretManager):
 
     def create_token(
         self,
-        ttl: str | int,
+        ttl: str | int | None = None,
         *,
         policies: list[str] | None = None,
         renewable: bool | None = None,
@@ -388,10 +389,13 @@ class OpenBaoSecretManager(AbstractSecretManager):
         """Create a new scoped child token using the manager's root/admin token."""
 
         duration = self._stringify_duration(ttl)
-        if not duration:
-            raise ValueError("A TTL must be provided when creating a token.")
+        token_period = self._stringify_duration(period)
+        if not duration and not token_period:
+            raise ValueError("A TTL or period must be provided when creating a token.")
 
-        payload: Dict[str, Any] = {"ttl": duration}
+        payload: Dict[str, Any] = {}
+        if duration:
+            payload["ttl"] = duration
         if policies is not None:
             payload["policies"] = policies
         if renewable is not None:
@@ -402,8 +406,8 @@ class OpenBaoSecretManager(AbstractSecretManager):
             payload["num_uses"] = num_uses
         if no_default_policy is not None:
             payload["no_default_policy"] = no_default_policy
-        if period is not None:
-            payload["period"] = self._stringify_duration(period)
+        if token_period is not None:
+            payload["period"] = token_period
         if metadata:
             payload["meta"] = metadata
 
@@ -428,6 +432,13 @@ class OpenBaoSecretManager(AbstractSecretManager):
 
         return self._request(
             "POST", "/v1/auth/token/lookup", data={"token": token}
+        ).get("data", {})
+
+    def lookup_accessor(self, accessor: str) -> Dict[str, Any]:
+        """Lookup token metadata by accessor without needing the token value."""
+
+        return self._request(
+            "POST", "/v1/auth/token/lookup-accessor", data={"accessor": accessor}
         ).get("data", {})
 
     def renew_self(self, increment: str | int | None = None) -> Dict[str, Any]:
@@ -458,11 +469,34 @@ class OpenBaoSecretManager(AbstractSecretManager):
             raise RuntimeError("OpenBao did not return token renewal information.")
         return auth
 
+    def renew_accessor(
+        self, accessor: str, increment: str | int | None = None
+    ) -> Dict[str, Any]:
+        """Renew a token by accessor using the current token's privileges."""
+
+        payload: Dict[str, Any] = {"accessor": accessor}
+        if increment is not None:
+            payload["increment"] = self._stringify_duration(increment)
+        response = self._request("POST", "/v1/auth/token/renew-accessor", data=payload)
+        auth = response.get("auth", {})
+        if not auth:
+            raise RuntimeError("OpenBao did not return token renewal information.")
+        return auth
+
+    def revoke_accessor(self, accessor: str) -> None:
+        """Revoke a token by accessor using the current token's privileges."""
+
+        self._request(
+            "POST",
+            "/v1/auth/token/revoke-accessor",
+            data={"accessor": accessor},
+            expected_status=(200, 204),
+        )
+
     def get_access_secrets(self) -> Dict[str, Any] | None:
         return {
             "address": self.address,
             "token": self.token,
             "mount_path": self.mount_path,
             "verify_tls": self.verify_tls,
-            "unseal_keys": list(self.unseal_keys),
         }

--- a/mlox/services/openbao/docker.py
+++ b/mlox/services/openbao/docker.py
@@ -260,12 +260,10 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
         self,
         infra: Infrastructure | None = None,
         *,
-        ttl: str | int | None = None,
-        renewable: bool = True,
         application_name: str = "",
-        period: str | int | None = "24h",
+        period: str | int = "24h",
     ) -> OpenBaoSecretManager:
-        """Create or rotate a named application token for a downloaded keyfile."""
+        """Create or rotate a periodic application token for a keyfile."""
 
         application = self._normalize_application_name(application_name)
         manager = self.get_root_secret_manager(infra)
@@ -288,19 +286,16 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
         }
         token_options: Dict[str, Any] = {
             "policies": [self.kv_policy_name],
-            "renewable": renewable,
+            "renewable": True,
+            "period": period,
             "metadata": metadata,
         }
-        if ttl is not None:
-            token_options["ttl"] = ttl
-        if period is not None:
-            token_options["period"] = period
         auth = manager.create_token(**token_options)
         self._store_application_credential(
             application,
             auth,
-            ttl=str(ttl) if ttl is not None else "",
-            period=str(period) if period is not None else "",
+            ttl="",
+            period=str(period),
         )
         return OpenBaoSecretManager(
             address=manager.address,
@@ -314,16 +309,13 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
         application_name: str,
         infra: Infrastructure | None = None,
         *,
-        ttl: str | int | None = None,
-        period: str | int | None = "24h",
+        period: str | int = "24h",
     ) -> Dict[str, Any]:
         """Create a renewable application credential without exposing its token."""
 
         application = self._normalize_application_name(application_name)
         self.create_keyfile_secret_manager(
             infra,
-            ttl=ttl,
-            renewable=True,
             application_name=application,
             period=period,
         )

--- a/mlox/services/openbao/docker.py
+++ b/mlox/services/openbao/docker.py
@@ -20,16 +20,18 @@ from __future__ import annotations
 import logging
 import json
 import re
+from datetime import datetime, timezone
 import shlex
 import time
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Any, Dict
 
 from mlox.execution.base import TaskGroup
 from mlox.infra import Infrastructure
 from mlox.secret_manager import AbstractSecretManager, AbstractSecretManagerService
 from mlox.service import AbstractService
 from .client import OpenBaoSecretManager
+from mlox.utils import generate_password
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +45,22 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
     root_token: str = ""
     key_shares: int = 1
     key_threshold: int = 1
+    userpass_path: str = "userpass"
+    admin_username: str = "mlox-admin"
+    admin_password: str = ""
+    kv_policy_name: str = "mlox-kv-rw"
+    ui_policy_name: str = "mlox-ui-kv-admin"
+    client_token: str = ""
+    client_token_accessor: str = ""
+    client_token_ttl: str = "24h"
+    client_token_max_ttl: str = "168h"
+    client_token_lease_duration: int = 0
+    client_token_renewable: bool = True
+    client_token_last_renewed_at: str = ""
     compose_service_names: Dict[str, str] = field(init=False, default_factory=dict)
-    unseal_keys: list[str] = field(default_factory=list, init=False)
-    service_url: str = field(default="", init=False)
-    stack_prefix: str = field(default="", init=False)
+    unseal_keys: list[str] = field(default_factory=list)
+    service_url: str = ""
+    stack_prefix: str = ""
 
     def __post_init__(self) -> None:
         self.port = int(self.port)
@@ -117,6 +131,7 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
         if result:
             logger.info("Bootstrapping OpenBao production instance.")
             self._bootstrap_openbao(conn)
+            self._configure_mlox_access(conn)
             logger.info("OpenBao bootstrap completed.")
         self.state = "running" if result else "unknown"
         return result
@@ -159,37 +174,88 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
             return {"status": "unknown", "error": str(exc)}
 
     def get_secrets(self) -> Dict[str, Dict]:
-        if not self.root_token:
+        if not self.client_token:
             return {}
         return {
-            "openbao_root_credentials": {
-                "token": self.root_token,
-                "root_token": self.root_token,
-                "unseal_keys": list(self.unseal_keys),
+            "openbao_client_credentials": {
+                "token": self.client_token,
                 "address": self.service_url,
                 "mount_path": self.mount_path,
                 "verify_tls": False,
+                "renewable": self.client_token_renewable,
+                "lease_duration": self.client_token_lease_duration,
+                "token_accessor": self.client_token_accessor,
             }
         }
 
     # ------------------------------------------------------------------
     # AbstractSecretManagerService implementation
     # ------------------------------------------------------------------
-    def get_secret_manager(self, infra: Infrastructure) -> AbstractSecretManager:
-        bundle = infra.get_bundle_by_service(self)
-        if bundle is None:
-            raise ValueError(
-                "OpenBao service is not attached to a bundle in the infrastructure"
-            )
+    def get_secret_manager(
+        self, infra: Infrastructure | None = None
+    ) -> AbstractSecretManager:
+        address = self.service_url
+        if infra is not None:
+            bundle = infra.get_bundle_by_service(self)
+            if bundle is None:
+                raise ValueError(
+                    "OpenBao service is not attached to a bundle in the infrastructure"
+                )
+            address = f"https://{bundle.server.ip}:{self.port}"
+        if not address:
+            raise ValueError("OpenBao service URL is not configured.")
 
-        server = bundle.server
-        address = f"https://{server.ip}:{self.port}"
+        token = self.client_token or self.root_token
+        if not token:
+            raise ValueError("OpenBao client token is not configured.")
+        return OpenBaoSecretManager(
+            address=address,
+            token=token,
+            mount_path=self.mount_path,
+            unseal_keys=list(self.unseal_keys),
+        )
+
+    def get_root_secret_manager(
+        self, infra: Infrastructure | None = None
+    ) -> OpenBaoSecretManager:
+        """Return a bootstrap/recovery client that uses the root token."""
+
+        address = self.service_url
+        if infra is not None:
+            bundle = infra.get_bundle_by_service(self)
+            if bundle is None:
+                raise ValueError(
+                    "OpenBao service is not attached to a bundle in the infrastructure"
+                )
+            address = f"https://{bundle.server.ip}:{self.port}"
+        if not address:
+            raise ValueError("OpenBao service URL is not configured.")
+        if not self.root_token:
+            raise ValueError("OpenBao root token is not configured.")
         return OpenBaoSecretManager(
             address=address,
             token=self.root_token,
             mount_path=self.mount_path,
             unseal_keys=list(self.unseal_keys),
         )
+
+    def renew_client_token(
+        self, infra: Infrastructure | None = None, increment: str | int | None = None
+    ) -> Dict[str, Any]:
+        """Renew the scoped mlox client token and update stored metadata."""
+
+        manager = self.get_secret_manager(infra)
+        auth = manager.renew_self(increment or self.client_token_ttl)
+        self._store_client_token_auth(auth)
+        return auth
+
+    def rotate_client_token(self, infra: Infrastructure | None = None) -> Dict[str, Any]:
+        """Create a replacement scoped mlox client token using the root token."""
+
+        manager = self.get_root_secret_manager(infra)
+        auth = self._create_client_token(manager)
+        self._store_client_token_auth(auth)
+        return auth
 
     def _render_config(self, host: str) -> str:
         node_id = f"mlox-openbao-{self.uuid[:8]}"
@@ -212,6 +278,125 @@ listener "tcp" {{
   tls_key_file = "/openbao/tls/key.pem"
 }}
 """
+
+    def _root_api_client(self, conn) -> OpenBaoSecretManager:
+        address = self.service_url or f"https://{conn.host}:{self.port}"
+        return OpenBaoSecretManager(
+            address=address,
+            token=self.root_token,
+            mount_path=self.mount_path,
+            unseal_keys=list(self.unseal_keys),
+        )
+
+    def _render_kv_policy(self) -> str:
+        mount = self.mount_path.strip("/") or "secret"
+        return f'''path "{mount}/data/*" {{
+  capabilities = ["create", "update", "read", "patch"]
+}}
+
+path "{mount}/metadata" {{
+  capabilities = ["list", "read"]
+}}
+
+path "{mount}/metadata/*" {{
+  capabilities = ["list", "read"]
+}}
+'''
+
+    def _render_ui_policy(self) -> str:
+        mount = self.mount_path.strip("/") or "secret"
+        return f'''path "{mount}/data/*" {{
+  capabilities = ["create", "update", "read", "patch", "delete"]
+}}
+
+path "{mount}/metadata" {{
+  capabilities = ["list", "read", "delete"]
+}}
+
+path "{mount}/metadata/*" {{
+  capabilities = ["list", "read", "delete"]
+}}
+
+path "sys/internal/ui/mounts" {{
+  capabilities = ["read"]
+}}
+
+path "sys/internal/ui/mounts/*" {{
+  capabilities = ["read"]
+}}
+'''
+
+    def _configure_mlox_access(self, conn) -> None:
+        if not self.root_token:
+            raise RuntimeError("OpenBao root token is required for mlox access setup.")
+
+        manager = self._root_api_client(conn)
+        logger.info("Ensuring OpenBao KV v2 mount '%s' exists via API.", self.mount_path)
+        manager.ensure_kv_v2(self.mount_path)
+        logger.info("Ensuring OpenBao file audit device exists via API.")
+        manager.enable_file_audit()
+        logger.info("Writing OpenBao mlox policies.")
+        manager.write_policy(self.kv_policy_name, self._render_kv_policy())
+        manager.write_policy(self.ui_policy_name, self._render_ui_policy())
+        logger.info("Ensuring OpenBao userpass auth is configured.")
+        manager.ensure_userpass_auth(self.userpass_path)
+        if not self.admin_password:
+            self.admin_password = generate_password(length=24, with_punctuation=False)
+        manager.create_or_update_userpass_user(
+            self.admin_username,
+            self.admin_password,
+            policies=[self.ui_policy_name],
+            ttl="8h",
+            max_ttl="24h",
+            path=self.userpass_path,
+        )
+        if not self._client_token_is_valid(manager):
+            logger.info("Creating scoped OpenBao client token for mlox.")
+            self._store_client_token_auth(self._create_client_token(manager))
+
+    def _client_token_is_valid(self, manager: OpenBaoSecretManager) -> bool:
+        if not self.client_token:
+            return False
+        try:
+            token_data = manager.lookup_token(self.client_token)
+        except Exception as exc:  # pragma: no cover - defensive OpenBao path
+            logger.info("Existing OpenBao client token is not valid: %s", exc)
+            return False
+        ttl = int(token_data.get("ttl") or 0)
+        if ttl <= 0:
+            return False
+        self.client_token_accessor = str(
+            token_data.get("accessor") or self.client_token_accessor or ""
+        )
+        self.client_token_lease_duration = ttl
+        self.client_token_renewable = bool(token_data.get("renewable", True))
+        return True
+
+    def _create_client_token(self, manager: OpenBaoSecretManager) -> Dict[str, Any]:
+        return manager.create_token(
+            ttl=self.client_token_ttl,
+            policies=[self.kv_policy_name],
+            renewable=True,
+            explicit_max_ttl=self.client_token_max_ttl,
+            metadata={
+                "managed_by": "mlox",
+                "service_uuid": self.uuid,
+                "purpose": "mlox-secret-manager-client",
+            },
+        )
+
+    def _store_client_token_auth(self, auth: Dict[str, Any]) -> None:
+        token = auth.get("client_token")
+        if token:
+            self.client_token = str(token)
+        accessor = auth.get("accessor")
+        if accessor:
+            self.client_token_accessor = str(accessor)
+        if auth.get("lease_duration") is not None:
+            self.client_token_lease_duration = int(auth.get("lease_duration") or 0)
+        if auth.get("renewable") is not None:
+            self.client_token_renewable = bool(auth.get("renewable"))
+        self.client_token_last_renewed_at = datetime.now(timezone.utc).isoformat()
 
     def _bootstrap_openbao(self, conn) -> None:
         health = self._wait_for_container_health(conn)
@@ -264,27 +449,6 @@ listener "tcp" {{
         if not self.root_token:
             raise RuntimeError("OpenBao is initialized but no root token is available.")
 
-        logger.info("Ensuring OpenBao KV v2 mount '%s' exists.", self.mount_path)
-        self._bao(
-            conn,
-            "secrets",
-            "enable",
-            f"-path={self.mount_path}",
-            "-version=2",
-            "kv",
-            token=self.root_token,
-            allow_failure=True,
-        )
-        logger.info("Ensuring OpenBao file audit device exists.")
-        self._bao(
-            conn,
-            "audit",
-            "enable",
-            "file",
-            "file_path=/openbao/logs/audit.log",
-            token=self.root_token,
-            allow_failure=True,
-        )
 
     def _wait_for_container_health(self, conn) -> Dict:
         last_error: Exception | None = None

--- a/mlox/services/openbao/docker.py
+++ b/mlox/services/openbao/docker.py
@@ -57,6 +57,7 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
     client_token_lease_duration: int = 0
     client_token_renewable: bool = True
     client_token_last_renewed_at: str = ""
+    application_credentials: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     compose_service_names: Dict[str, str] = field(init=False, default_factory=dict)
     unseal_keys: list[str] = field(default_factory=list)
     service_url: str = ""
@@ -205,14 +206,12 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
         if not address:
             raise ValueError("OpenBao service URL is not configured.")
 
-        token = self.client_token or self.root_token
-        if not token:
+        if not self.client_token:
             raise ValueError("OpenBao client token is not configured.")
         return OpenBaoSecretManager(
             address=address,
-            token=token,
+            token=self.client_token,
             mount_path=self.mount_path,
-            unseal_keys=list(self.unseal_keys),
         )
 
     def get_root_secret_manager(
@@ -257,6 +256,173 @@ class OpenBaoDockerService(AbstractService, AbstractSecretManagerService):
         self._store_client_token_auth(auth)
         return auth
 
+    def create_keyfile_secret_manager(
+        self,
+        infra: Infrastructure | None = None,
+        *,
+        ttl: str | int | None = None,
+        renewable: bool = True,
+        application_name: str = "",
+        period: str | int | None = "24h",
+    ) -> OpenBaoSecretManager:
+        """Create or rotate a named application token for a downloaded keyfile."""
+
+        application = self._normalize_application_name(application_name)
+        manager = self.get_root_secret_manager(infra)
+        previous = self.application_credentials.get(application, {})
+        previous_accessor = previous.get("accessor")
+        if previous_accessor:
+            try:
+                manager.revoke_accessor(str(previous_accessor))
+            except Exception as exc:  # pragma: no cover - best-effort cleanup
+                logger.info(
+                    "Could not revoke previous OpenBao token for application %s: %s",
+                    application,
+                    exc,
+                )
+        metadata = {
+            "managed_by": "mlox",
+            "service_uuid": self.uuid,
+            "purpose": "mlox-secret-manager-keyfile",
+            "application_name": application,
+        }
+        token_options: Dict[str, Any] = {
+            "policies": [self.kv_policy_name],
+            "renewable": renewable,
+            "metadata": metadata,
+        }
+        if ttl is not None:
+            token_options["ttl"] = ttl
+        if period is not None:
+            token_options["period"] = period
+        auth = manager.create_token(**token_options)
+        self._store_application_credential(
+            application,
+            auth,
+            ttl=str(ttl) if ttl is not None else "",
+            period=str(period) if period is not None else "",
+        )
+        return OpenBaoSecretManager(
+            address=manager.address,
+            token=str(auth["client_token"]),
+            mount_path=self.mount_path,
+            verify_tls=manager.verify_tls,
+        )
+
+    def create_application_credential(
+        self,
+        application_name: str,
+        infra: Infrastructure | None = None,
+        *,
+        ttl: str | int | None = None,
+        period: str | int | None = "24h",
+    ) -> Dict[str, Any]:
+        """Create a renewable application credential without exposing its token."""
+
+        application = self._normalize_application_name(application_name)
+        self.create_keyfile_secret_manager(
+            infra,
+            ttl=ttl,
+            renewable=True,
+            application_name=application,
+            period=period,
+        )
+        return self.application_credentials[application]
+
+    def renew_application_credential(
+        self,
+        application_name: str,
+        infra: Infrastructure | None = None,
+        increment: str | int | None = None,
+    ) -> Dict[str, Any]:
+        application = self._normalize_application_name(application_name)
+        credential = self.application_credentials.get(application)
+        if not credential or not credential.get("accessor"):
+            raise ValueError(f"No OpenBao credential is registered for {application}.")
+        manager = self.get_root_secret_manager(infra)
+        auth = manager.renew_accessor(str(credential["accessor"]), increment)
+        credential["lease_duration"] = int(auth.get("lease_duration") or 0)
+        credential["renewable"] = bool(auth.get("renewable", True))
+        credential["last_renewed_at"] = datetime.now(timezone.utc).isoformat()
+        self.application_credentials[application] = credential
+        return auth
+
+    def revoke_application_credential(
+        self, application_name: str, infra: Infrastructure | None = None
+    ) -> None:
+        application = self._normalize_application_name(application_name)
+        credential = self.application_credentials.get(application)
+        if not credential or not credential.get("accessor"):
+            raise ValueError(f"No OpenBao credential is registered for {application}.")
+        manager = self.get_root_secret_manager(infra)
+        manager.revoke_accessor(str(credential["accessor"]))
+        self.application_credentials.pop(application, None)
+
+    def refresh_application_credentials(
+        self, infra: Infrastructure | None = None
+    ) -> Dict[str, Dict[str, Any]]:
+        manager = self.get_root_secret_manager(infra)
+        refreshed: Dict[str, Dict[str, Any]] = {}
+        for application, credential in list(self.application_credentials.items()):
+            accessor = credential.get("accessor")
+            if not accessor:
+                continue
+            try:
+                token_data = manager.lookup_accessor(str(accessor))
+            except Exception as exc:  # pragma: no cover - defensive OpenBao path
+                logger.info(
+                    "Could not refresh OpenBao credential for %s: %s",
+                    application,
+                    exc,
+                )
+                credential["status"] = "unknown"
+                refreshed[application] = credential
+                continue
+            credential["lease_duration"] = int(token_data.get("ttl") or 0)
+            credential["renewable"] = bool(token_data.get("renewable", True))
+            credential["status"] = (
+                "active" if int(credential["lease_duration"] or 0) > 0 else "expired"
+            )
+            credential["last_checked_at"] = datetime.now(timezone.utc).isoformat()
+            refreshed[application] = credential
+        self.application_credentials = refreshed
+        return self.application_credentials
+
+    @staticmethod
+    def _normalize_application_name(application_name: str) -> str:
+        application = re.sub(r"[^A-Za-z0-9_.-]+", "-", application_name.strip())
+        application = application.strip("-._")
+        if application.endswith(".json"):
+            application = application[:-5]
+        if not application:
+            raise ValueError("Application name is required.")
+        return application
+
+    def _store_application_credential(
+        self,
+        application: str,
+        auth: Dict[str, Any],
+        *,
+        ttl: str,
+        period: str = "",
+    ) -> None:
+        accessor = auth.get("accessor")
+        if not accessor:
+            raise RuntimeError("OpenBao did not return a token accessor.")
+        now = datetime.now(timezone.utc).isoformat()
+        self.application_credentials[application] = {
+            "application_name": application,
+            "accessor": str(accessor),
+            "ttl": ttl,
+            "period": period,
+            "renewable": bool(auth.get("renewable", True)),
+            "lease_duration": int(auth.get("lease_duration") or 0),
+            "created_at": now,
+            "last_rotated_at": now,
+            "status": "active",
+            "keyfile_name": f"{application}.json",
+        }
+
     def _render_config(self, host: str) -> str:
         node_id = f"mlox-openbao-{self.uuid[:8]}"
         api_addr = f"https://{host}:{self.port}"
@@ -276,6 +442,13 @@ listener "tcp" {{
   tls_disable = false
   tls_cert_file = "/openbao/tls/cert.pem"
   tls_key_file = "/openbao/tls/key.pem"
+}}
+
+audit "file" "file" {{
+  description = "mlox OpenBao audit log"
+  options {{
+    file_path = "/openbao/logs/audit.log"
+  }}
 }}
 """
 
@@ -333,8 +506,6 @@ path "sys/internal/ui/mounts/*" {{
         manager = self._root_api_client(conn)
         logger.info("Ensuring OpenBao KV v2 mount '%s' exists via API.", self.mount_path)
         manager.ensure_kv_v2(self.mount_path)
-        logger.info("Ensuring OpenBao file audit device exists via API.")
-        manager.enable_file_audit()
         logger.info("Writing OpenBao mlox policies.")
         manager.write_policy(self.kv_policy_name, self._render_kv_policy())
         manager.write_policy(self.ui_policy_name, self._render_ui_policy())

--- a/mlox/view/secret_manager.py
+++ b/mlox/view/secret_manager.py
@@ -8,6 +8,15 @@ from mlox.utils import generate_pw
 from mlox.view.utils import st_hack_align
 from mlox.secret_manager import get_encrypted_access_keyfile
 
+APPLICATION_PERIOD_OPTIONS: dict[str, str] = {
+    "1 hour": "1h",
+    "8 hours": "8h",
+    "24 hours": "24h",
+    "7 days": "168h",
+    "30 days": "720h",
+    "90 days": "2160h",
+}
+
 # Lightweight CSS for badges, chips, and custom tables
 st.markdown(
     """
@@ -138,24 +147,67 @@ def secrets() -> None:
                 "Download the keyfile for this secret manager. It contains the access information required to connect to it."
             )
             c1, c2, c3 = st.columns(3)
-            keyfile_name = c1.text_input(
-                "Keyfile Name",
-                value=f"{secret_manager_service.name}.json",
-                key=f"keyfile_name_{secret_manager_service.name}",
+            application_name = c1.text_input(
+                "Application",
+                value=secret_manager_service.name,
+                key=f"keyfile_application_{secret_manager_service.name}",
             )
+            keyfile_name = f"{application_name.strip() or secret_manager_service.name}.json"
             keyfile_pw = c2.text_input(
                 "Password",
                 value=generate_pw(16),
                 key=f"keyfile_pw_{secret_manager_service.name}",
             )
-
-            encrypted_keyfile_dict = get_encrypted_access_keyfile(
-                secret_manager, keyfile_pw
+            supports_scoped_ttl = hasattr(
+                secret_manager_service, "create_keyfile_secret_manager"
             )
+            period_label = "24 hours"
+            if supports_scoped_ttl:
+                period_label = c3.selectbox(
+                    "Renewal period",
+                    options=list(APPLICATION_PERIOD_OPTIONS.keys()),
+                    index=2,
+                    key=f"keyfile_ttl_{secret_manager_service.name}",
+                )
+
+            generated_key = f"generated_access_keyfile_{secret_manager_service.uuid}"
+            signature_key = f"{generated_key}_signature"
+            keyfile_signature = (
+                application_name,
+                keyfile_pw,
+                APPLICATION_PERIOD_OPTIONS.get(period_label)
+                if supports_scoped_ttl
+                else None,
+            )
+            if supports_scoped_ttl:
+                period = APPLICATION_PERIOD_OPTIONS[period_label]
+                if st.session_state.get(signature_key) != keyfile_signature:
+                    keyfile_secret_manager = (
+                        secret_manager_service.create_keyfile_secret_manager(
+                            infra,
+                            period=period,
+                            application_name=application_name,
+                        )
+                    )
+                    st.session_state[generated_key] = get_encrypted_access_keyfile(
+                        keyfile_secret_manager, keyfile_pw
+                    )
+                    st.session_state[signature_key] = keyfile_signature
+                    try:
+                        st.session_state.mlox.save_infrastructure()
+                    except Exception:
+                        pass
+                encrypted_keyfile = st.session_state[generated_key]
+                st.caption(f"Renewal period: `{period}`")
+            else:
+                encrypted_keyfile = get_encrypted_access_keyfile(
+                    secret_manager, keyfile_pw
+                )
+
             st_hack_align(c3)
             c3.download_button(
                 "Download Keyfile",
-                data=encrypted_keyfile_dict,
+                data=encrypted_keyfile,
                 file_name=keyfile_name,
                 mime="application/json",
                 icon=":material/download:",

--- a/mlox/view/secret_manager.py
+++ b/mlox/view/secret_manager.py
@@ -135,17 +135,38 @@ def secrets() -> None:
         st.markdown("**Path**")
         st.code(selected["path"], language="bash")
 
+    supports_periodic_credentials = hasattr(
+        secret_manager_service, "create_keyfile_secret_manager"
+    )
     if st.toggle(
-        "Download Keyfile",
+        "Download Application Keyfile"
+        if supports_periodic_credentials
+        else "Download Keyfile",
         value=False,
         key=f"toggle_download_access_keyfile_{secret_manager_service.name}",
-        help="Download the keyfile for this service. It contains the secrets and server information.",
+        help=(
+            "Create a periodic scoped application credential and download its "
+            "encrypted access keyfile."
+            if supports_periodic_credentials
+            else "Download the encrypted access keyfile for this secret manager."
+        ),
     ):
         with st.container(horizontal_alignment="distribute", border=True):
-            st.markdown("#### Download Access Keyfile")
-            st.caption(
-                "Download the keyfile for this secret manager. It contains the access information required to connect to it."
+            st.markdown(
+                "#### Download Application Keyfile"
+                if supports_periodic_credentials
+                else "#### Download Access Keyfile"
             )
+            if supports_periodic_credentials:
+                st.info(
+                    "OpenBao creates a periodic, renewable token for this application. "
+                    "The application must renew it before the selected period expires. "
+                    "Generating the same application again rotates its previous token."
+                )
+            else:
+                st.caption(
+                    "Download the access information required to connect to this secret manager."
+                )
             c1, c2, c3 = st.columns(3)
             application_name = c1.text_input(
                 "Application",
@@ -158,16 +179,13 @@ def secrets() -> None:
                 value=generate_pw(16),
                 key=f"keyfile_pw_{secret_manager_service.name}",
             )
-            supports_scoped_ttl = hasattr(
-                secret_manager_service, "create_keyfile_secret_manager"
-            )
             period_label = "24 hours"
-            if supports_scoped_ttl:
+            if supports_periodic_credentials:
                 period_label = c3.selectbox(
                     "Renewal period",
                     options=list(APPLICATION_PERIOD_OPTIONS.keys()),
                     index=2,
-                    key=f"keyfile_ttl_{secret_manager_service.name}",
+                    key=f"keyfile_period_{secret_manager_service.name}",
                 )
 
             generated_key = f"generated_access_keyfile_{secret_manager_service.uuid}"
@@ -176,10 +194,10 @@ def secrets() -> None:
                 application_name,
                 keyfile_pw,
                 APPLICATION_PERIOD_OPTIONS.get(period_label)
-                if supports_scoped_ttl
+                if supports_periodic_credentials
                 else None,
             )
-            if supports_scoped_ttl:
+            if supports_periodic_credentials:
                 period = APPLICATION_PERIOD_OPTIONS[period_label]
                 if st.session_state.get(signature_key) != keyfile_signature:
                     keyfile_secret_manager = (
@@ -206,7 +224,9 @@ def secrets() -> None:
 
             st_hack_align(c3)
             c3.download_button(
-                "Download Keyfile",
+                "Download Application Keyfile"
+                if supports_periodic_credentials
+                else "Download Keyfile",
                 data=encrypted_keyfile,
                 file_name=keyfile_name,
                 mime="application/json",

--- a/mlox/view/services/openbao.py
+++ b/mlox/view/services/openbao.py
@@ -52,34 +52,100 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
     sealed = bool(status.get("sealed", False)) if status else False
     st.write(f"Initialized: `{initialized}`")
     st.write(f"Sealed: `{sealed}`")
-    st.write(f"Root Token: `{_mask_secret(service.root_token)}`")
-    if service.root_token and st.toggle(
-        "Show full root token",
+    st.write("Namespace: `root`")
+
+    st.markdown("### UI Login")
+    st.caption("Use these credentials for OpenBao UI access instead of the root token.")
+    st.write(f"Method: `{service.userpass_path}`")
+    st.text_input(
+        "Username",
+        value=service.admin_username,
+        disabled=True,
+        key=f"openbao_admin_username_{service.uuid}",
+    )
+    if service.admin_password and st.toggle(
+        "Show UI password",
         value=False,
-        key=f"openbao_show_root_token_{service.uuid}",
+        key=f"openbao_show_admin_password_{service.uuid}",
     ):
         st.text_input(
-            "Root Token",
-            value=service.root_token,
+            "Password",
+            value=service.admin_password,
             disabled=True,
             type="default",
-            key=f"openbao_root_token_{service.uuid}",
+            key=f"openbao_admin_password_{service.uuid}",
         )
-    st.write(f"Unseal Keys: `{len(service.unseal_keys)}`")
-    if service.unseal_keys and st.toggle(
-        "Show unseal keys",
-        value=False,
-        key=f"openbao_show_unseal_keys_{service.uuid}",
+
+    st.markdown("### mlox Client Token")
+    st.write(f"Token: `{_mask_secret(service.client_token)}`")
+    st.write(f"Accessor: `{service.client_token_accessor or '-'}`")
+    st.write(f"Renewable: `{service.client_token_renewable}`")
+    st.write(f"Lease Duration: `{service.client_token_lease_duration}` seconds")
+    if service.client_token_last_renewed_at:
+        st.write(f"Last Updated: `{service.client_token_last_renewed_at}`")
+
+    token_cols = st.columns(2)
+    if token_cols[0].button(
+        "Renew client token",
+        type="primary",
+        key=f"openbao_renew_client_token_{service.uuid}",
     ):
-        for idx, unseal_key in enumerate(service.unseal_keys, start=1):
+        try:
+            service.renew_client_token(infra)
+            st.session_state.pop(key, None)
+            try:
+                st.session_state.mlox.save_infrastructure()
+            except Exception:
+                pass
+            st.success("OpenBao client token renewed.")
+            st.rerun()
+        except Exception as exc:
+            st.error(f"Could not renew OpenBao client token: {exc}")
+    if token_cols[1].button(
+        "Rotate client token",
+        key=f"openbao_rotate_client_token_{service.uuid}",
+    ):
+        try:
+            service.rotate_client_token(infra)
+            st.session_state.pop(key, None)
+            try:
+                st.session_state.mlox.save_infrastructure()
+            except Exception:
+                pass
+            st.success("OpenBao client token rotated.")
+            st.rerun()
+        except Exception as exc:
+            st.error(f"Could not rotate OpenBao client token: {exc}")
+
+    with st.expander("Emergency recovery material"):
+        st.warning("Use root and unseal material only for recovery or bootstrap tasks.")
+        st.write(f"Root Token: `{_mask_secret(service.root_token)}`")
+        if service.root_token and st.toggle(
+            "Show full root token",
+            value=False,
+            key=f"openbao_show_root_token_{service.uuid}",
+        ):
             st.text_input(
-                f"Unseal Key {idx}",
-                value=unseal_key,
+                "Root Token",
+                value=service.root_token,
                 disabled=True,
                 type="default",
-                key=f"openbao_unseal_key_{service.uuid}_{idx}",
+                key=f"openbao_root_token_{service.uuid}",
             )
-    st.write("Namespace: `root`")
+        st.write(f"Unseal Keys: `{len(service.unseal_keys)}`")
+        if service.unseal_keys and st.toggle(
+            "Show unseal keys",
+            value=False,
+            key=f"openbao_show_unseal_keys_{service.uuid}",
+        ):
+            for idx, unseal_key in enumerate(service.unseal_keys, start=1):
+                st.text_input(
+                    f"Unseal Key {idx}",
+                    value=unseal_key,
+                    disabled=True,
+                    type="default",
+                    key=f"openbao_unseal_key_{service.uuid}_{idx}",
+                )
 
     if sealed:
         if not service.unseal_keys:

--- a/mlox/view/services/openbao.py
+++ b/mlox/view/services/openbao.py
@@ -98,15 +98,34 @@ def _usage_markdown() -> str:
 
 def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerService):
     key = f"openbao_secret_manager_{service.uuid}"
-    if key not in st.session_state:
-        st.session_state[key] = service.get_secret_manager(infra)
-    manager = st.session_state[key]
+    manager = st.session_state.get(key)
+    if manager is None and service.client_token:
+        try:
+            manager = service.get_secret_manager(infra)
+            st.session_state[key] = manager
+        except Exception:
+            manager = None
 
     service_token_error: Exception | None = None
+    service_token_ttl = int(service.client_token_lease_duration or 0)
+    if manager is not None:
+        try:
+            token_data = manager.lookup_self()
+            service_token_ttl = int(token_data.get("ttl") or 0)
+            service.client_token_lease_duration = service_token_ttl
+            service.client_token_renewable = bool(
+                token_data.get("renewable", service.client_token_renewable)
+            )
+        except Exception as exc:
+            service_token_error = exc
+
     try:
-        status = manager.seal_status()
-    except Exception as exc:
-        service_token_error = exc
+        status = (
+            manager.seal_status()
+            if manager is not None
+            else service.get_root_secret_manager(infra).seal_status()
+        )
+    except Exception:
         try:
             status = service.get_root_secret_manager(infra).seal_status()
         except Exception:
@@ -115,13 +134,15 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
     initialized = bool(status.get("initialized", bool(service.root_token)))
     sealed = bool(status.get("sealed", False)) if status else False
     service_token_expired = (
-        bool(service_token_error)
-        or bool(service.client_token and service.client_token_lease_duration <= 0)
+        not bool(service.client_token)
+        or manager is None
+        or bool(service_token_error)
+        or service_token_ttl <= 0
     )
     status_cols = st.columns(4)
     status_cols[0].metric("Initialized", "Yes" if initialized else "No")
     status_cols[1].metric("Seal", "Sealed" if sealed else "Open")
-    status_cols[2].metric("Client TTL", _format_ttl(service.client_token_lease_duration))
+    status_cols[2].metric("Client TTL", _format_ttl(service_token_ttl))
     status_cols[3].metric("Applications", len(service.application_credentials))
 
     usage_markdown = _usage_markdown()
@@ -196,7 +217,7 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
         )
         token_cols[3].text_input(
             "Lease",
-            value=_format_ttl(service.client_token_lease_duration),
+            value=_format_ttl(service_token_ttl),
             disabled=True,
             key=f"openbao_client_lease_{service.uuid}",
         )
@@ -325,7 +346,7 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
                     "Rotation period",
                     options=list(APPLICATION_PERIOD_OPTIONS.keys()),
                     index=2,
-                    key=f"openbao_selected_keyfile_ttl_{service.uuid}_{selected_application}",
+                    key=f"openbao_selected_keyfile_period_{service.uuid}_{selected_application}",
                 )
                 if app_action_cols[2].button(
                     "Renew",
@@ -406,6 +427,8 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
             )
         else:
             try:
+                if manager is None:
+                    raise RuntimeError("OpenBao mlox service token is unavailable.")
                 secrets = manager.list_secrets(keys_only=True)
             except Exception as exc:
                 st.warning(f"Could not list OpenBao secrets: {exc}")
@@ -474,8 +497,9 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
                 icon=":material/lock_open:",
                 key=f"openbao_unseal_{service.uuid}",
             ):
+                recovery_manager = manager or service.get_root_secret_manager(infra)
                 for unseal_key in service.unseal_keys:
-                    status = manager.unseal(unseal_key)
+                    status = recovery_manager.unseal(unseal_key)
                     if not bool(status.get("sealed", True)):
                         break
                 if bool(status.get("sealed", True)):

--- a/mlox/view/services/openbao.py
+++ b/mlox/view/services/openbao.py
@@ -3,15 +3,28 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
 import streamlit as st
 
 from mlox.infra import Infrastructure, Bundle
+from mlox.secret_manager import get_encrypted_access_keyfile
+from mlox.utils import generate_pw
 from mlox.view.services.common import save_to_secret_store
 
 from mlox.services.openbao import OpenBaoDockerService
+
+
+APPLICATION_PERIOD_OPTIONS: dict[str, str] = {
+    "1 hour": "1h",
+    "8 hours": "8h",
+    "24 hours": "24h",
+    "7 days": "168h",
+    "30 days": "720h",
+    "90 days": "2160h",
+}
 
 
 def _format_secret_value(value: Any) -> str:
@@ -35,89 +48,445 @@ def _mask_secret(value: str) -> str:
     return f"{value[:4]}...{value[-4:]}"
 
 
+def _save_infra() -> None:
+    try:
+        st.session_state.mlox.save_infrastructure()
+    except Exception:
+        pass
+
+
+def _format_ttl(seconds: int | str | None) -> str:
+    try:
+        value = int(seconds or 0)
+    except (TypeError, ValueError):
+        return "-"
+    if value <= 0:
+        return "expired"
+    if value >= 86400:
+        return f"{value // 86400}d"
+    if value >= 3600:
+        return f"{value // 3600}h"
+    if value >= 60:
+        return f"{value // 60}m"
+    return f"{value}s"
+
+
+def _credential_rows(service: OpenBaoDockerService) -> pd.DataFrame:
+    rows = []
+    for name, credential in sorted(service.application_credentials.items()):
+        accessor = str(credential.get("accessor", ""))
+        rows.append(
+            {
+                "Application": name,
+                "Status": credential.get("status", "active"),
+                "TTL": _format_ttl(credential.get("lease_duration")),
+                "Renewable": bool(credential.get("renewable", True)),
+                "Period": credential.get("period") or "-",
+                "Accessor": f"{accessor[:12]}..." if accessor else "-",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _usage_markdown() -> str:
+    usage_path = Path(__file__).resolve().parents[2] / "services/openbao/USAGE.md"
+    try:
+        return usage_path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
 def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerService):
     key = f"openbao_secret_manager_{service.uuid}"
     if key not in st.session_state:
         st.session_state[key] = service.get_secret_manager(infra)
     manager = st.session_state[key]
 
-    st.markdown("### Bootstrap")
+    service_token_error: Exception | None = None
     try:
         status = manager.seal_status()
     except Exception as exc:
-        status = {}
-        st.warning(f"Could not read OpenBao seal status: {exc}")
+        service_token_error = exc
+        try:
+            status = service.get_root_secret_manager(infra).seal_status()
+        except Exception:
+            status = {}
 
     initialized = bool(status.get("initialized", bool(service.root_token)))
     sealed = bool(status.get("sealed", False)) if status else False
-    st.write(f"Initialized: `{initialized}`")
-    st.write(f"Sealed: `{sealed}`")
-    st.write("Namespace: `root`")
-
-    st.markdown("### UI Login")
-    st.caption("Use these credentials for OpenBao UI access instead of the root token.")
-    st.write(f"Method: `{service.userpass_path}`")
-    st.text_input(
-        "Username",
-        value=service.admin_username,
-        disabled=True,
-        key=f"openbao_admin_username_{service.uuid}",
+    service_token_expired = (
+        bool(service_token_error)
+        or bool(service.client_token and service.client_token_lease_duration <= 0)
     )
-    if service.admin_password and st.toggle(
-        "Show UI password",
-        value=False,
-        key=f"openbao_show_admin_password_{service.uuid}",
-    ):
-        st.text_input(
-            "Password",
-            value=service.admin_password,
+    status_cols = st.columns(4)
+    status_cols[0].metric("Initialized", "Yes" if initialized else "No")
+    status_cols[1].metric("Seal", "Sealed" if sealed else "Open")
+    status_cols[2].metric("Client TTL", _format_ttl(service.client_token_lease_duration))
+    status_cols[3].metric("Applications", len(service.application_credentials))
+
+    usage_markdown = _usage_markdown()
+    if usage_markdown:
+        with st.expander("How to use this secret manager", expanded=False):
+            st.markdown(usage_markdown)
+
+    access_tab, apps_tab, secrets_tab, recovery_tab = st.tabs(
+        ["Access", "Applications", "Secrets", "Recovery"]
+    )
+
+    with access_tab:
+        st.markdown("#### Browser Login")
+        st.caption("Use userpass for the OpenBao UI. Root credentials stay in recovery.")
+        login_cols = st.columns(3)
+        login_cols[0].text_input(
+            "Method",
+            value=service.userpass_path,
             disabled=True,
-            type="default",
-            key=f"openbao_admin_password_{service.uuid}",
+            key=f"openbao_userpass_path_{service.uuid}",
         )
+        login_cols[1].text_input(
+            "Username",
+            value=service.admin_username,
+            disabled=True,
+            key=f"openbao_admin_username_{service.uuid}",
+        )
+        if service.admin_password and login_cols[2].toggle(
+            "Show password",
+            value=False,
+            key=f"openbao_show_admin_password_{service.uuid}",
+        ):
+            st.text_input(
+                "Password",
+                value=service.admin_password,
+                disabled=True,
+                type="default",
+                key=f"openbao_admin_password_{service.uuid}",
+            )
 
-    st.markdown("### mlox Client Token")
-    st.write(f"Token: `{_mask_secret(service.client_token)}`")
-    st.write(f"Accessor: `{service.client_token_accessor or '-'}`")
-    st.write(f"Renewable: `{service.client_token_renewable}`")
-    st.write(f"Lease Duration: `{service.client_token_lease_duration}` seconds")
-    if service.client_token_last_renewed_at:
-        st.write(f"Last Updated: `{service.client_token_last_renewed_at}`")
-
-    token_cols = st.columns(2)
-    if token_cols[0].button(
-        "Renew client token",
-        type="primary",
-        key=f"openbao_renew_client_token_{service.uuid}",
-    ):
-        try:
-            service.renew_client_token(infra)
-            st.session_state.pop(key, None)
+        st.markdown("#### mlox Service Token")
+        if service_token_expired:
+            st.warning(
+                "The mlox service token may be expired or invalid. Secret browsing "
+                "can fail until it is replaced. Use `Rotate client token` to create "
+                "a fresh scoped token; mlox will save the updated token automatically."
+            )
+        else:
+            st.info(
+                "The mlox service token is the scoped credential used for normal "
+                "mlox secret operations. Root remains reserved for recovery and "
+                "credential administration."
+            )
+        token_cols = st.columns(4)
+        token_cols[0].text_input(
+            "Token",
+            value=_mask_secret(service.client_token),
+            disabled=True,
+            key=f"openbao_client_token_masked_{service.uuid}",
+        )
+        token_cols[1].text_input(
+            "Accessor",
+            value=service.client_token_accessor or "-",
+            disabled=True,
+            key=f"openbao_client_accessor_{service.uuid}",
+        )
+        token_cols[2].text_input(
+            "Renewable",
+            value=str(service.client_token_renewable),
+            disabled=True,
+            key=f"openbao_client_renewable_{service.uuid}",
+        )
+        token_cols[3].text_input(
+            "Lease",
+            value=_format_ttl(service.client_token_lease_duration),
+            disabled=True,
+            key=f"openbao_client_lease_{service.uuid}",
+        )
+        action_cols = st.columns(2)
+        if action_cols[0].button(
+            "Renew client token",
+            type="primary",
+            key=f"openbao_renew_client_token_{service.uuid}",
+            width="stretch",
+        ):
             try:
-                st.session_state.mlox.save_infrastructure()
-            except Exception:
-                pass
-            st.success("OpenBao client token renewed.")
-            st.rerun()
-        except Exception as exc:
-            st.error(f"Could not renew OpenBao client token: {exc}")
-    if token_cols[1].button(
-        "Rotate client token",
-        key=f"openbao_rotate_client_token_{service.uuid}",
-    ):
-        try:
-            service.rotate_client_token(infra)
-            st.session_state.pop(key, None)
+                service.renew_client_token(infra)
+                st.session_state.pop(key, None)
+                _save_infra()
+                st.success("OpenBao client token renewed.")
+                st.rerun()
+            except Exception as exc:
+                st.error(
+                    "Could not renew the mlox service token. If it already expired, "
+                    "use `Rotate client token` to create and save a replacement."
+                )
+        if action_cols[1].button(
+            "Rotate client token",
+            key=f"openbao_rotate_client_token_{service.uuid}",
+            width="stretch",
+        ):
             try:
-                st.session_state.mlox.save_infrastructure()
-            except Exception:
-                pass
-            st.success("OpenBao client token rotated.")
-            st.rerun()
-        except Exception as exc:
-            st.error(f"Could not rotate OpenBao client token: {exc}")
+                old_token = service.client_token
+                service.rotate_client_token(infra)
+                st.session_state.pop(key, None)
+                if service.client_token != old_token:
+                    _save_infra()
+                st.success("OpenBao client token rotated.")
+                st.rerun()
+            except Exception as exc:
+                st.error(f"Could not rotate OpenBao client token: {exc}")
 
-    with st.expander("Emergency recovery material"):
+    with apps_tab:
+        st.markdown("#### Application Credentials")
+        st.caption(
+            "Each application has a renewable scoped token. mlox stores only the accessor."
+        )
+        with st.form(f"openbao_add_application_credential_{service.uuid}"):
+            add_cols = st.columns(3)
+            new_application = add_cols[0].text_input(
+                "Application",
+                placeholder="my-app",
+                key=f"openbao_new_application_{service.uuid}",
+            )
+            new_period_label = add_cols[1].selectbox(
+                "Renewal period",
+                options=list(APPLICATION_PERIOD_OPTIONS.keys()),
+                index=2,
+                key=f"openbao_new_application_ttl_{service.uuid}",
+            )
+            with add_cols[2]:
+                st.markdown("&nbsp;", unsafe_allow_html=True)
+                submitted = st.form_submit_button(
+                    "Add credential",
+                    type="primary",
+                    width="stretch",
+                )
+            if submitted:
+                try:
+                    period = APPLICATION_PERIOD_OPTIONS[new_period_label]
+                    service.create_application_credential(
+                        new_application,
+                        infra,
+                        period=period,
+                    )
+                    _save_infra()
+                    st.success(f"Added credential for {new_application}.")
+                    st.rerun()
+                except Exception as exc:
+                    st.error(f"Could not add application credential: {exc}")
+
+        if st.button(
+            "Refresh credential status",
+            key=f"openbao_refresh_application_credentials_{service.uuid}",
+        ):
+            try:
+                service.refresh_application_credentials(infra)
+                _save_infra()
+                st.rerun()
+            except Exception as exc:
+                st.error(f"Could not refresh application credentials: {exc}")
+
+        credentials_df = _credential_rows(service)
+        if credentials_df.empty:
+            st.info("No application credentials have been generated yet.")
+        else:
+            selection = st.dataframe(
+                credentials_df,
+                hide_index=True,
+                selection_mode="single-row",
+                width="stretch",
+                on_select="rerun",
+                key=f"openbao_application_credentials_table_{service.uuid}",
+            )
+            selected_rows = selection.get("selection", {}).get("rows", [])
+            if selected_rows:
+                selected_application = credentials_df.iloc[selected_rows[0]][
+                    "Application"
+                ]
+                st.markdown(f"#### `{selected_application}`")
+                selected = service.application_credentials.get(
+                    str(selected_application), {}
+                )
+                detail_cols = st.columns(4)
+                detail_cols[0].metric("Status", str(selected.get("status", "active")))
+                detail_cols[1].metric(
+                    "TTL", _format_ttl(selected.get("lease_duration"))
+                )
+                detail_cols[2].metric(
+                    "Renewable", "Yes" if selected.get("renewable", True) else "No"
+                )
+                detail_cols[3].metric("Period", selected.get("period") or "-")
+
+                app_action_cols = st.columns(5)
+                keyfile_pw = app_action_cols[0].text_input(
+                    "Keyfile password",
+                    value=generate_pw(16),
+                    key=f"openbao_selected_keyfile_pw_{service.uuid}_{selected_application}",
+                )
+                period_label = app_action_cols[1].selectbox(
+                    "Rotation period",
+                    options=list(APPLICATION_PERIOD_OPTIONS.keys()),
+                    index=2,
+                    key=f"openbao_selected_keyfile_ttl_{service.uuid}_{selected_application}",
+                )
+                if app_action_cols[2].button(
+                    "Renew",
+                    type="primary",
+                    key=f"openbao_renew_application_{service.uuid}_{selected_application}",
+                    width="stretch",
+                ):
+                    try:
+                        service.renew_application_credential(
+                            str(selected_application), infra
+                        )
+                        _save_infra()
+                        st.success(f"Renewed {selected_application}.")
+                        st.rerun()
+                    except Exception as exc:
+                        st.error(f"Could not renew {selected_application}: {exc}")
+                if app_action_cols[3].button(
+                    "Revoke",
+                    key=f"openbao_revoke_application_{service.uuid}_{selected_application}",
+                    width="stretch",
+                ):
+                    try:
+                        service.revoke_application_credential(
+                            str(selected_application), infra
+                        )
+                        _save_infra()
+                        st.success(f"Revoked {selected_application}.")
+                        st.rerun()
+                    except Exception as exc:
+                        st.error(f"Could not revoke {selected_application}: {exc}")
+
+                period = APPLICATION_PERIOD_OPTIONS[period_label]
+                download_state_key = (
+                    f"openbao_selected_keyfile_{service.uuid}_{selected_application}"
+                )
+                signature_key = f"{download_state_key}_signature"
+                signature = (selected_application, keyfile_pw, period_label)
+                if app_action_cols[4].button(
+                    "Rotate keyfile",
+                    key=f"openbao_rotate_application_{service.uuid}_{selected_application}",
+                    width="stretch",
+                ):
+                    try:
+                        keyfile_manager = service.create_keyfile_secret_manager(
+                            infra,
+                            period=period,
+                            application_name=str(selected_application),
+                        )
+                        st.session_state[download_state_key] = (
+                            get_encrypted_access_keyfile(keyfile_manager, keyfile_pw)
+                        )
+                        st.session_state[signature_key] = signature
+                        _save_infra()
+                    except Exception as exc:
+                        st.error(f"Could not rotate {selected_application}: {exc}")
+                if (
+                    download_state_key in st.session_state
+                    and st.session_state.get(signature_key) == signature
+                ):
+                    st.download_button(
+                        "Download rotated keyfile",
+                        data=st.session_state[download_state_key],
+                        file_name=f"{selected_application}.json",
+                        mime="application/json",
+                        icon=":material/download:",
+                        type="primary",
+                        key=f"openbao_download_selected_keyfile_{service.uuid}_{selected_application}",
+                    )
+
+    with secrets_tab:
+        if sealed:
+            st.warning("OpenBao is sealed. Unseal it in the Recovery tab first.")
+        elif service_token_expired:
+            st.warning(
+                "Secret browsing is disabled because the mlox service token may be "
+                "expired or invalid. Rotate the client token in the Access tab, then "
+                "return here."
+            )
+        else:
+            try:
+                secrets = manager.list_secrets(keys_only=True)
+            except Exception as exc:
+                st.warning(f"Could not list OpenBao secrets: {exc}")
+                secrets = {}
+
+            df = pd.DataFrame(
+                [[name, "****"] for name in secrets.keys()], columns=["Key", "Value"]
+            )
+            selection = st.dataframe(
+                df,
+                hide_index=True,
+                selection_mode="single-row",
+                width="stretch",
+                on_select="rerun",
+                key=f"openbao_secrets_table_{service.uuid}",
+            )
+
+            if len(selection["selection"]["rows"]) > 0:
+                idx = selection["selection"]["rows"][0]
+                secret_key = df.iloc[idx]["Key"]
+                secret_value = manager.load_secret(secret_key)
+                if secret_value is None:
+                    st.info("Could not load secret from OpenBao.")
+                else:
+                    save_to_secret_store(infra, secret_key, secret_value)
+                    st.markdown(f"#### `{secret_key}`")
+                    formatted = _format_secret_value(secret_value)
+                    if isinstance(secret_value, dict) and st.toggle(
+                        "Tree View",
+                        value=False,
+                        key=f"openbao_tree_{secret_key}",
+                    ):
+                        st.write(secret_value)
+                    else:
+                        st.text_area(
+                            "Value",
+                            value=formatted,
+                            height=240,
+                            disabled=True,
+                            key=f"openbao_value_{secret_key}",
+                        )
+                    st.download_button(
+                        "Download secret",
+                        data=formatted,
+                        file_name=f"{secret_key.lower()}.json",
+                        mime="application/json",
+                        icon=":material/download:",
+                        key=f"openbao_download_{secret_key}",
+                    )
+            else:
+                with st.form("openbao_add_secret"):
+                    name = st.text_input("Key")
+                    value = st.text_area("Value", placeholder="JSON or text")
+                    if st.form_submit_button("Add Secret"):
+                        manager.save_secret(name, value)
+                        st.rerun()
+
+    with recovery_tab:
+        st.markdown("#### Seal Recovery")
+        if sealed:
+            if not service.unseal_keys:
+                st.warning("OpenBao is sealed and no unseal key is stored in mlox state.")
+            elif st.button(
+                "Unseal",
+                type="primary",
+                icon=":material/lock_open:",
+                key=f"openbao_unseal_{service.uuid}",
+            ):
+                for unseal_key in service.unseal_keys:
+                    status = manager.unseal(unseal_key)
+                    if not bool(status.get("sealed", True)):
+                        break
+                if bool(status.get("sealed", True)):
+                    st.error("OpenBao remained sealed after submitting stored unseal keys.")
+                else:
+                    st.success("OpenBao unsealed.")
+                    st.rerun()
+        else:
+            st.info("OpenBao is unsealed.")
+
+        st.markdown("#### Emergency Material")
         st.warning("Use root and unseal material only for recovery or bootstrap tasks.")
         st.write(f"Root Token: `{_mask_secret(service.root_token)}`")
         if service.root_token and st.toggle(
@@ -146,83 +515,3 @@ def settings(infra: Infrastructure, bundle: Bundle, service: OpenBaoDockerServic
                     type="default",
                     key=f"openbao_unseal_key_{service.uuid}_{idx}",
                 )
-
-    if sealed:
-        if not service.unseal_keys:
-            st.warning("OpenBao is sealed and no unseal key is stored in mlox state.")
-            return
-        if st.button(
-            "Unseal",
-            type="primary",
-            icon=":material/lock_open:",
-            key=f"openbao_unseal_{service.uuid}",
-        ):
-            for unseal_key in service.unseal_keys:
-                status = manager.unseal(unseal_key)
-                if not bool(status.get("sealed", True)):
-                    break
-            if bool(status.get("sealed", True)):
-                st.error("OpenBao remained sealed after submitting stored unseal keys.")
-            else:
-                st.success("OpenBao unsealed.")
-                st.rerun()
-        return
-
-    try:
-        secrets = manager.list_secrets(keys_only=True)
-    except Exception as exc:
-        st.warning(f"Could not list OpenBao secrets: {exc}")
-        return
-
-    df = pd.DataFrame(
-        [[name, "****"] for name in secrets.keys()], columns=["Key", "Value"]
-    )
-    selection = st.dataframe(
-        df,
-        hide_index=True,
-        selection_mode="single-row",
-        width="stretch",
-        on_select="rerun",
-    )
-
-    if len(selection["selection"]["rows"]) > 0:
-        idx = selection["selection"]["rows"][0]
-        secret_key = df.iloc[idx]["Key"]
-        secret_value = manager.load_secret(secret_key)
-        if secret_value is None:
-            st.info("Could not load secret from OpenBao.")
-        else:
-            save_to_secret_store(infra, secret_key, secret_value)
-            with st.container(border=True):
-                st.markdown(f"### `{secret_key}`")
-                if isinstance(secret_value, dict) and st.toggle(
-                    "Tree View",
-                    value=False,
-                    key=f"openbao_tree_{secret_key}",
-                ):
-                    st.write(secret_value)
-                else:
-                    formatted = _format_secret_value(secret_value)
-                    st.text_area(
-                        "Value",
-                        value=formatted,
-                        height=240,
-                        disabled=True,
-                        key=f"openbao_value_{secret_key}",
-                    )
-                    if formatted:
-                        st.download_button(
-                            "Download",
-                            data=formatted,
-                            file_name=f"{secret_key.lower()}.json",
-                            mime="application/json",
-                            icon=":material/download:",
-                            key=f"openbao_download_{secret_key}",
-                        )
-    else:
-        with st.form("openbao_add_secret"):
-            name = st.text_input("Key")
-            value = st.text_area("Value", placeholder="JSON or text")
-            if st.form_submit_button("Add Secret"):
-                manager.save_secret(name, value)
-                st.rerun()

--- a/tests/integration/test_service_openbao.py
+++ b/tests/integration/test_service_openbao.py
@@ -196,6 +196,10 @@ def test_openbao_secret_manager_is_self_contained(install_openbao_service):
     sm.save_secret(secret_name, secret_payload)
     access = sm.get_access_secrets()
     assert access
+    assert access.get("token") == service.client_token
+    assert access.get("token") != service.root_token
+    assert "unseal_keys" not in access
+    assert "root_token" not in access
 
     restored = OpenBaoSecretManager.instantiate_secret_manager(access)
     assert restored is not None

--- a/tests/integration/test_service_openbao.py
+++ b/tests/integration/test_service_openbao.py
@@ -52,6 +52,10 @@ def test_openbao_service_is_running(install_openbao_service):
     assert service.service_url
     assert service.root_token
     assert service.unseal_keys
+    assert service.admin_username
+    assert service.admin_password
+    assert service.client_token
+    assert service.client_token != service.root_token
 
 
 def test_openbao_secret_roundtrip(install_openbao_service):
@@ -61,6 +65,7 @@ def test_openbao_secret_roundtrip(install_openbao_service):
     assert isinstance(sm, OpenBaoSecretManager)
     assert sm.is_working()
     assert sm.address.startswith("https://")
+    assert sm.token == service.client_token
 
     secret_name = "integration-secret"
     secret_payload = {"alpha": 1, "beta": "value"}
@@ -75,11 +80,13 @@ def test_openbao_secret_roundtrip(install_openbao_service):
     assert secret_name in keys_only and keys_only[secret_name] is None
 
     secrets = service.get_secrets()
-    assert "openbao_root_credentials" in secrets
-    creds = secrets["openbao_root_credentials"]
-    assert creds.get("token") == service.root_token
-    assert creds.get("root_token") == service.root_token
-    assert creds.get("unseal_keys") == service.unseal_keys
+    assert "openbao_client_credentials" in secrets
+    assert "openbao_root_credentials" not in secrets
+    creds = secrets["openbao_client_credentials"]
+    assert creds.get("token") == service.client_token
+    assert creds.get("token") != service.root_token
+    assert "root_token" not in creds
+    assert "unseal_keys" not in creds
     assert creds.get("address", "").startswith("https://")
     assert creds.get("verify_tls") is False
     assert service.compose_service_names["OpenBao"].endswith("_openbao")
@@ -103,7 +110,7 @@ def test_openbao_restart_preserves_raft_data(install_openbao_service):
 
 def test_openbao_create_token_allows_child_access(install_openbao_service):
     infra, _bundle, service = install_openbao_service
-    sm = service.get_secret_manager(infra)
+    sm = service.get_root_secret_manager(infra)
 
     secret_name = "integration-token-secret"
     secret_payload = {"token": generate_password(length=16, with_punctuation=False)}
@@ -139,7 +146,7 @@ def test_openbao_create_token_allows_child_access(install_openbao_service):
 
 def test_openbao_create_token_honors_options(install_openbao_service):
     infra, _bundle, service = install_openbao_service
-    sm = service.get_secret_manager(infra)
+    sm = service.get_root_secret_manager(infra)
 
     auth = sm.create_token(
         ttl="90s",
@@ -160,3 +167,36 @@ def test_openbao_create_token_honors_options(install_openbao_service):
     assert 0 < ttl_seconds <= 90
     assert info.get("renewable") is False
     assert info.get("num_uses") == 2
+
+
+def test_openbao_userpass_login_and_client_token_renewal(install_openbao_service):
+    infra, _bundle, service = install_openbao_service
+    root_manager = service.get_root_secret_manager(infra)
+
+    user_auth = root_manager.login_userpass(
+        service.admin_username, service.admin_password, path=service.userpass_path
+    )
+    assert user_auth.get("client_token")
+    assert user_auth.get("client_token") != service.root_token
+
+    previous_token = service.client_token
+    auth = service.renew_client_token(infra, increment="10m")
+    assert auth.get("lease_duration", 0) > 0
+    assert service.client_token
+    assert service.client_token == auth.get("client_token", previous_token)
+    assert service.client_token_lease_duration > 0
+
+
+def test_openbao_secret_manager_is_self_contained(install_openbao_service):
+    infra, _bundle, service = install_openbao_service
+    secret_name = "integration-self-contained"
+    secret_payload = {"self_contained": True}
+
+    sm = service.get_secret_manager(infra)
+    sm.save_secret(secret_name, secret_payload)
+    access = sm.get_access_secrets()
+    assert access
+
+    restored = OpenBaoSecretManager.instantiate_secret_manager(access)
+    assert restored is not None
+    assert restored.load_secret(secret_name) == secret_payload

--- a/tests/unit/test_service_secrets.py
+++ b/tests/unit/test_service_secrets.py
@@ -78,15 +78,23 @@ SERVICE_CASES = [
     ),
     (
         OpenBaoDockerService,
-        {"root_token": "root-token", "port": "8200", "mount_path": "kv"},
         {
-            "openbao_root_credentials": {
-                "token": "root-token",
-                "root_token": "root-token",
-                "unseal_keys": [],
+            "root_token": "root-token",
+            "client_token": "client-token",
+            "client_token_accessor": "accessor",
+            "client_token_lease_duration": 86400,
+            "port": "8200",
+            "mount_path": "kv",
+        },
+        {
+            "openbao_client_credentials": {
+                "token": "client-token",
                 "address": "https://example.test:8200",
                 "mount_path": "kv",
                 "verify_tls": False,
+                "renewable": True,
+                "lease_duration": 86400,
+                "token_accessor": "accessor",
             }
         },
         lambda service: setattr(service, "service_url", "https://example.test:8200"),

--- a/tests/unit/test_services_docker_adapters.py
+++ b/tests/unit/test_services_docker_adapters.py
@@ -300,6 +300,8 @@ def test_openbao_setup_spin_check_and_secret_manager(conn):
     assert "tls_disable = false" in config
     assert 'tls_cert_file = "/openbao/tls/cert.pem"' in config
     assert 'tls_key_file = "/openbao/tls/key.pem"' in config
+    assert 'audit "file" "file"' in config
+    assert 'file_path = "/openbao/logs/audit.log"' in config
     compose = Path("mlox/services/openbao/docker-compose-openbao.yaml").read_text()
     assert "server -dev" not in compose
     assert "dev-root-token" not in compose
@@ -317,6 +319,14 @@ def test_openbao_setup_spin_check_and_secret_manager(conn):
     assert service.state == "running"
     assert service.root_token == "root"
     assert service.client_token == "client"
+    service.unseal_keys = ["unseal-key"]
+    access_secrets = service.get_secret_manager().get_access_secrets()
+    assert access_secrets == {
+        "address": "https://example.test:8200",
+        "token": "client",
+        "mount_path": "kv",
+        "verify_tls": False,
+    }
     execute_calls = [call for call in service.exec.calls if call[0] == "execute"]
     assert execute_calls
     assert execute_calls[-1][1][0].startswith("timeout 300s docker compose")
@@ -340,6 +350,16 @@ def test_openbao_setup_spin_check_and_secret_manager(conn):
     secrets = service.get_secrets()["openbao_client_credentials"]
     assert secrets["token"] == "client"
     assert "root_token" not in secrets
+
+    root_only_service = _set_exec(
+        OpenBaoDockerService(
+            **BASE, port="8200", mount_path="kv", root_token="root-only"
+        ),
+        FakeExec(),
+    )
+    root_only_service.service_url = "https://example.test:8200"
+    with pytest.raises(ValueError, match="client token"):
+        root_only_service.get_secret_manager()
 
 
 def test_openbao_configure_mlox_access(conn, monkeypatch):
@@ -367,7 +387,6 @@ def test_openbao_configure_mlox_access(conn, monkeypatch):
         return inner
 
     monkeypatch.setattr(OpenBaoSecretManager, "ensure_kv_v2", record("ensure_kv_v2"))
-    monkeypatch.setattr(OpenBaoSecretManager, "enable_file_audit", record("audit"))
     monkeypatch.setattr(OpenBaoSecretManager, "write_policy", record("policy"))
     monkeypatch.setattr(
         OpenBaoSecretManager, "ensure_userpass_auth", record("userpass")
@@ -385,8 +404,95 @@ def test_openbao_configure_mlox_access(conn, monkeypatch):
     assert service.client_token_accessor == "acc"
     assert service.client_token_lease_duration == 86400
     assert any(call[0] == "ensure_kv_v2" and call[1][1:] == ("kv",) for call in calls)
+    assert not any(call[0] == "audit" for call in calls)
     assert any(call[0] == "user" for call in calls)
     assert any(call[0] == "policy" for call in calls)
+
+
+def test_openbao_create_keyfile_secret_manager_uses_fresh_scoped_token(monkeypatch):
+    service = OpenBaoDockerService(
+        **BASE,
+        port="8200",
+        mount_path="kv",
+        root_token="root",
+        kv_policy_name="mlox-kv",
+    )
+    service.service_url = "https://example.test:8200"
+    calls = []
+
+    root_manager = OpenBaoSecretManager(
+        address="https://example.test:8200",
+        token="root",
+        mount_path="kv",
+        verify_tls=False,
+        unseal_keys=["unseal"],
+    )
+
+    def create_token(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "client_token": "keyfile-token",
+            "accessor": "keyfile-accessor",
+            "lease_duration": 3600,
+            "renewable": True,
+        }
+
+    monkeypatch.setattr(root_manager, "create_token", create_token)
+    monkeypatch.setattr(service, "get_root_secret_manager", lambda *_: root_manager)
+
+    keyfile_manager = service.create_keyfile_secret_manager(
+        period="1h",
+        application_name="demo-app.json",
+    )
+
+    assert keyfile_manager.address == "https://example.test:8200"
+    assert keyfile_manager.token == "keyfile-token"
+    assert keyfile_manager.mount_path == "kv"
+    assert keyfile_manager.get_access_secrets() == {
+        "address": "https://example.test:8200",
+        "token": "keyfile-token",
+        "mount_path": "kv",
+        "verify_tls": False,
+    }
+    assert calls == [
+        (
+            (),
+            {
+                "policies": ["mlox-kv"],
+                "renewable": True,
+                "period": "1h",
+                "metadata": {
+                    "managed_by": "mlox",
+                    "service_uuid": service.uuid,
+                    "purpose": "mlox-secret-manager-keyfile",
+                    "application_name": "demo-app",
+                },
+            },
+        )
+    ]
+    assert service.application_credentials["demo-app"]["accessor"] == "keyfile-accessor"
+    assert service.application_credentials["demo-app"]["lease_duration"] == 3600
+    assert service.application_credentials["demo-app"]["period"] == "1h"
+
+    def renew_accessor(accessor, increment=None):
+        assert accessor == "keyfile-accessor"
+        assert increment is None
+        return {"lease_duration": 7200, "renewable": True}
+
+    revoked = []
+    monkeypatch.setattr(root_manager, "renew_accessor", renew_accessor)
+    monkeypatch.setattr(root_manager, "revoke_accessor", lambda accessor: revoked.append(accessor))
+
+    service.renew_application_credential("demo-app")
+    assert service.application_credentials["demo-app"]["lease_duration"] == 7200
+    service.revoke_application_credential("demo-app")
+    assert revoked == ["keyfile-accessor"]
+    assert "demo-app" not in service.application_credentials
+
+    credential = service.create_application_credential("demo-app", period="2160h")
+    assert credential["application_name"] == "demo-app"
+    assert credential["accessor"] == "keyfile-accessor"
+    assert credential["period"] == "2160h"
 
 
 def test_openbao_health_wait_requires_real_status(conn, monkeypatch):
@@ -967,8 +1073,14 @@ def test_openbao_secret_manager_core_paths(monkeypatch):
             return {"data": {"ttl": 300}}
         if method == "POST" and path == "/v1/auth/token/lookup":
             return {"data": {"ttl": 300}}
+        if method == "POST" and path == "/v1/auth/token/lookup-accessor":
+            return {"data": {"ttl": 300, "renewable": True}}
         if method == "POST" and path == "/v1/auth/token/renew-self":
             return {"auth": {"client_token": "tok", "lease_duration": 300}}
+        if method == "POST" and path == "/v1/auth/token/renew-accessor":
+            return {"auth": {"lease_duration": 300, "renewable": True}}
+        if method == "POST" and path == "/v1/auth/token/revoke-accessor":
+            return {}
         return {}
 
     monkeypatch.setattr(manager, "_request", _request)
@@ -988,7 +1100,10 @@ def test_openbao_secret_manager_core_paths(monkeypatch):
     assert manager.create_token(300)["client_token"] == "child-token"
     assert manager.lookup_self()["ttl"] == 300
     assert manager.lookup_token("tok")["ttl"] == 300
+    assert manager.lookup_accessor("acc")["ttl"] == 300
     assert manager.renew_self(300)["lease_duration"] == 300
+    assert manager.renew_accessor("acc", 300)["lease_duration"] == 300
+    manager.revoke_accessor("acc")
     assert manager.get_access_secrets()["mount_path"] == "kv"
     assert ("POST", "/v1/sys/init") in [(method, path) for method, path, _ in calls]
     assert ("POST", "/v1/sys/unseal") in [(method, path) for method, path, _ in calls]
@@ -1010,9 +1125,28 @@ def test_openbao_secret_manager_core_paths(monkeypatch):
     assert ("POST", "/v1/auth/token/renew-self") in [
         (method, path) for method, path, _ in calls
     ]
+    assert ("POST", "/v1/auth/token/renew-accessor") in [
+        (method, path) for method, path, _ in calls
+    ]
+    assert ("POST", "/v1/auth/token/revoke-accessor") in [
+        (method, path) for method, path, _ in calls
+    ]
     assert ("PUT", "/v1/sys/audit/file") in [
         (method, path) for method, path, _ in calls
     ]
+
+    def _api_audit_blocked(method, path, **kwargs):
+        assert method == "PUT"
+        assert path == "/v1/sys/audit/file"
+        return {
+            "errors": [
+                "cannot enable audit device via API; use declarative, "
+                "config-based audit device management instead"
+            ]
+        }
+
+    monkeypatch.setattr(manager, "_request", _api_audit_blocked)
+    manager.enable_file_audit()
 
     def _raise_404(method, path, **kwargs):
         raise HTTPError(url="http://bao", code=404, msg="not found", hdrs=None, fp=None)

--- a/tests/unit/test_services_docker_adapters.py
+++ b/tests/unit/test_services_docker_adapters.py
@@ -260,6 +260,14 @@ def test_openbao_setup_spin_check_and_secret_manager(conn):
         FakeExec(),
     )
     service._bootstrap_openbao = lambda *_: setattr(service, "root_token", "root")
+    service._configure_mlox_access = lambda *_: service._store_client_token_auth(
+        {
+            "client_token": "client",
+            "accessor": "accessor",
+            "lease_duration": 86400,
+            "renewable": True,
+        }
+    )
 
     service.setup(conn)
     assert service.port == 8200
@@ -308,6 +316,7 @@ def test_openbao_setup_spin_check_and_secret_manager(conn):
     assert service.spin_up(conn) is True
     assert service.state == "running"
     assert service.root_token == "root"
+    assert service.client_token == "client"
     execute_calls = [call for call in service.exec.calls if call[0] == "execute"]
     assert execute_calls
     assert execute_calls[-1][1][0].startswith("timeout 300s docker compose")
@@ -325,6 +334,59 @@ def test_openbao_setup_spin_check_and_secret_manager(conn):
     sm = service.get_secret_manager(infra)
     assert isinstance(sm, OpenBaoSecretManager)
     assert sm.address == "https://10.0.0.7:8200"
+    assert sm.token == "client"
+    root_sm = service.get_root_secret_manager(infra)
+    assert root_sm.token == "root"
+    secrets = service.get_secrets()["openbao_client_credentials"]
+    assert secrets["token"] == "client"
+    assert "root_token" not in secrets
+
+
+def test_openbao_configure_mlox_access(conn, monkeypatch):
+    service = _set_exec(
+        OpenBaoDockerService(**BASE, port="8200", mount_path="kv", root_token="root"),
+        FakeExec(),
+    )
+    service.service_url = "https://example.test:8200"
+    calls = []
+
+    def record(name):
+        def inner(*args, **kwargs):
+            calls.append((name, args, kwargs))
+            if name == "lookup_token":
+                raise RuntimeError("missing token")
+            if name == "create_token":
+                return {
+                    "client_token": "scoped",
+                    "accessor": "acc",
+                    "lease_duration": 86400,
+                    "renewable": True,
+                }
+            return {}
+
+        return inner
+
+    monkeypatch.setattr(OpenBaoSecretManager, "ensure_kv_v2", record("ensure_kv_v2"))
+    monkeypatch.setattr(OpenBaoSecretManager, "enable_file_audit", record("audit"))
+    monkeypatch.setattr(OpenBaoSecretManager, "write_policy", record("policy"))
+    monkeypatch.setattr(
+        OpenBaoSecretManager, "ensure_userpass_auth", record("userpass")
+    )
+    monkeypatch.setattr(
+        OpenBaoSecretManager, "create_or_update_userpass_user", record("user")
+    )
+    monkeypatch.setattr(OpenBaoSecretManager, "lookup_token", record("lookup_token"))
+    monkeypatch.setattr(OpenBaoSecretManager, "create_token", record("create_token"))
+
+    service._configure_mlox_access(conn)
+
+    assert service.admin_password
+    assert service.client_token == "scoped"
+    assert service.client_token_accessor == "acc"
+    assert service.client_token_lease_duration == 86400
+    assert any(call[0] == "ensure_kv_v2" and call[1][1:] == ("kv",) for call in calls)
+    assert any(call[0] == "user" for call in calls)
+    assert any(call[0] == "policy" for call in calls)
 
 
 def test_openbao_health_wait_requires_real_status(conn, monkeypatch):
@@ -878,8 +940,21 @@ def test_openbao_secret_manager_core_paths(monkeypatch):
             return {"root_token": "root", "keys_base64": ["key"]}
         if method == "POST" and path == "/v1/sys/unseal":
             return {"sealed": False}
+        if method == "GET" and path == "/v1/sys/mounts":
+            return {"data": {}}
         if method == "POST" and path == "/v1/sys/mounts/kv":
             return {}
+        if method == "POST" and path == "/v1/sys/policy/mlox":
+            return {}
+        if method == "GET" and path == "/v1/sys/auth":
+            return {"data": {}}
+        if method == "POST" and path == "/v1/sys/auth/userpass":
+            return {}
+        if method == "POST" and path == "/v1/auth/userpass/users/alice":
+            return {}
+        if method == "POST" and path == "/v1/auth/userpass/login/alice":
+            assert kwargs.get("include_token") is False
+            return {"auth": {"client_token": "user-token"}}
         if method == "PUT" and path == "/v1/sys/audit/file":
             return {}
         if method == "GET" and path == "/v1/kv/metadata":
@@ -888,6 +963,12 @@ def test_openbao_secret_manager_core_paths(monkeypatch):
             return {"data": {"data": {"x": 1}}}
         if method == "POST" and path.startswith("/v1/auth/token/create"):
             return {"auth": {"client_token": "child-token"}}
+        if method == "GET" and path == "/v1/auth/token/lookup-self":
+            return {"data": {"ttl": 300}}
+        if method == "POST" and path == "/v1/auth/token/lookup":
+            return {"data": {"ttl": 300}}
+        if method == "POST" and path == "/v1/auth/token/renew-self":
+            return {"auth": {"client_token": "tok", "lease_duration": 300}}
         return {}
 
     monkeypatch.setattr(manager, "_request", _request)
@@ -896,14 +977,37 @@ def test_openbao_secret_manager_core_paths(monkeypatch):
     assert manager.initialize(1, 1)["root_token"] == "root"
     assert manager.unseal("key")["sealed"] is False
     manager.enable_kv_v2("kv")
+    manager.ensure_kv_v2("kv")
+    manager.write_policy("mlox", "path \"kv/*\" {}")
+    manager.ensure_userpass_auth()
+    manager.create_or_update_userpass_user("alice", "pw", policies=["mlox"])
+    assert manager.login_userpass("alice", "pw")["client_token"] == "user-token"
     manager.enable_file_audit()
     assert manager.list_secrets(keys_only=False) == {"a": {"x": 1}}
     manager.save_secret("x", "{\"y\":1}")
     assert manager.create_token(300)["client_token"] == "child-token"
+    assert manager.lookup_self()["ttl"] == 300
+    assert manager.lookup_token("tok")["ttl"] == 300
+    assert manager.renew_self(300)["lease_duration"] == 300
     assert manager.get_access_secrets()["mount_path"] == "kv"
     assert ("POST", "/v1/sys/init") in [(method, path) for method, path, _ in calls]
     assert ("POST", "/v1/sys/unseal") in [(method, path) for method, path, _ in calls]
     assert ("POST", "/v1/sys/mounts/kv") in [
+        (method, path) for method, path, _ in calls
+    ]
+    assert ("POST", "/v1/sys/policy/mlox") in [
+        (method, path) for method, path, _ in calls
+    ]
+    assert ("POST", "/v1/sys/auth/userpass") in [
+        (method, path) for method, path, _ in calls
+    ]
+    assert ("POST", "/v1/auth/userpass/users/alice") in [
+        (method, path) for method, path, _ in calls
+    ]
+    assert ("POST", "/v1/auth/userpass/login/alice") in [
+        (method, path) for method, path, _ in calls
+    ]
+    assert ("POST", "/v1/auth/token/renew-self") in [
         (method, path) for method, path, _ in calls
     ]
     assert ("PUT", "/v1/sys/audit/file") in [


### PR DESCRIPTION
### Motivation
- Improve OpenBao production bootstrap by configuring least-privilege policies, enabling `userpass` UI login, and provisioning a renewable scoped client token for mlox instead of exposing the root token.
- Make the secret-manager client self-contained so external consumers can operate using only address, token, mount path and TLS settings.
- Surface token management and recovery workflows in the UI and automate client token lifecycle management during bootstrap.

### Description
- Updated runtime docs (`README.md`, added `USAGE.md`) to document `userpass` UI login, mlox-scoped policies, and the scoped client token usage and recovery guidance.
- Extended the OpenBao client (`mlox/services/openbao/client.py`) to support optional token header inclusion, list/ensure KV v2 mounts, policy CRUD, auth method listing/enabling, `userpass` user create/update and login, token lookup/renew/lookup-self, and `get_access_secrets` improvements so the client can be re-instantiated from exported access data.
- Enhanced the Docker adapter (`mlox/services/openbao/docker.py`) to generate and store mlox admin credentials, write KV/UI policies, enable `userpass`, create and manage a renewable scoped client token, add root-vs-client secret-manager helpers (`get_secret_manager` and `get_root_secret_manager`), and expose token rotation/renewal helpers and metadata storage.
- Updated the web UI (`mlox/view/services/openbao.py`) to show UI login credentials, client token metadata, actions to renew/rotate the client token, and an emergency expander exposing masked/unmasked recovery root token and unseal keys.
- Adjusted unit and integration tests to reflect the new behavior and added tests covering `userpass` login, client token renewal/rotation, self-contained secret-manager restore, and `configure_mlox_access` logic.

### Testing
- Ran unit test suite including `tests/unit/test_service_secrets.py` and `tests/unit/test_services_docker_adapters.py`, which exercise client methods and docker adapter flows; all modified and new unit tests passed.
- Ran integration tests in `tests/integration/test_service_openbao.py`, which validate bootstrap, secret roundtrip, persistence across restart, token creation, `userpass` login, and client token renewal; all modified and new integration tests passed.
- Verified core manual paths in unit mocks for `ensure_kv_v2`, policy writes, `userpass` flows, token lookup/renew, and audit enabling via the added tests which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20052b9840832294a1031b9a0054cd)