### PR TITLE
Add virtual 'connector' server backend and mark GCP services as connector-backed

### DIFF
--- a/mlox/config.py
+++ b/mlox/config.py
@@ -16,6 +16,7 @@ from mlox.service import (
     ServiceCapability,
 )
 from mlox.server import (
+    AbstractConnectorServer,
     AbstractDockerServer,
     AbstractFirewallServer,
     AbstractGitServer,
@@ -40,6 +41,7 @@ SERVER_CAPABILITY_ABCS = {
     ServerCapability.DOCKER.value: AbstractDockerServer,
     ServerCapability.KUBERNETES.value: AbstractKubernetesServer,
     ServerCapability.LOCAL.value: AbstractLocalServer,
+    ServerCapability.CONNECTOR.value: AbstractConnectorServer,
 }
 
 

--- a/mlox/infra.py
+++ b/mlox/infra.py
@@ -146,7 +146,7 @@ class Infrastructure:
         ]
 
     def filter_bundles_by_backend(
-        self, backend: Literal["docker", "kubernetes"]
+        self, backend: Literal["native", "docker", "kubernetes", "local", "connector"]
     ) -> List[Bundle]:
         return [b for b in self.bundles if backend in b.server.backend]
 

--- a/mlox/server.py
+++ b/mlox/server.py
@@ -117,6 +117,7 @@ class ServerCapability(StrEnum):
     DOCKER = "docker"
     KUBERNETES = "kubernetes"
     LOCAL = "local"
+    CONNECTOR = "connector"
 
 
 @dataclass
@@ -356,6 +357,13 @@ class AbstractKubernetesServer(AbstractBackendServer):
 
 @dataclass
 class AbstractLocalServer(AbstractBackendServer):
+    pass
+
+
+@dataclass
+class AbstractConnectorServer(AbstractBackendServer):
+    """Backend contract for virtual, externally hosted service connectors."""
+
     pass
 
 

--- a/mlox/servers/connector/__init__.py
+++ b/mlox/servers/connector/__init__.py
@@ -1,0 +1,5 @@
+"""Virtual connector server backend."""
+
+from .virtual import VirtualConnectorServer
+
+__all__ = ["VirtualConnectorServer"]

--- a/mlox/servers/connector/mlox-server.connector.yaml
+++ b/mlox/servers/connector/mlox-server.connector.yaml
@@ -1,0 +1,27 @@
+id: connector-server
+name: Connector Backend
+version: 0.1.0
+maintainer: MLOX
+description_short: Virtual backend for externally hosted connector services.
+description: |
+  Lightweight virtual server for connector services whose runtime is hosted
+  outside of MLOX, such as GCP Secret Manager, Google Sheets, BigQuery, and
+  other third-party service connectors. It does not provision a VM, VPS,
+  storage, memory, SSH, Docker, or Kubernetes runtime.
+links:
+  project: https://github.com/busysloths/mlox
+  news: https://mlox.org/
+groups:
+  experimental:
+  server:
+  backend:
+    connector:
+capabilities:
+  backend:
+    - connector
+build:
+  class_name: mlox.servers.connector.virtual.VirtualConnectorServer
+  params:
+    ip: connector.local
+    root: mlox_connector
+    root_pw: ""

--- a/mlox/servers/connector/mlox-server.connector.yaml
+++ b/mlox/servers/connector/mlox-server.connector.yaml
@@ -22,6 +22,6 @@ capabilities:
 build:
   class_name: mlox.servers.connector.virtual.VirtualConnectorServer
   params:
-    ip: connector.local
+    ip: ${MLOX_IP}
     root: mlox_connector
     root_pw: ""

--- a/mlox/servers/connector/virtual.py
+++ b/mlox/servers/connector/virtual.py
@@ -1,0 +1,167 @@
+"""Virtual connector server implementation.
+
+The connector server is a lightweight, non-physical home for services whose
+runtime exists outside of MLOX (for example Google Cloud Secret Manager,
+Sheets, BigQuery, or other connector-style integrations). It intentionally does
+not provision storage, RAM, SSH, Docker, or Kubernetes resources.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, ClassVar, IO
+
+from mlox.server import (
+    AbstractConnectorServer,
+    AbstractServer,
+    MloxUser,
+    ServerCapability,
+    ServerConnection,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _VirtualCommandResult:
+    """Minimal Fabric-like result for no-op virtual commands."""
+
+    def __init__(self, command: str, stdout: str = ""):
+        self.command = command
+        self.stdout = stdout
+        self.stderr = ""
+        self.return_code = 0
+        self.ok = True
+
+
+class VirtualConnection:
+    """Connection-like no-op object for connector services.
+
+    It provides the small Fabric-compatible surface used by service lifecycle
+    methods while avoiding any shell access to a real machine.
+    """
+
+    host = "connector.local"
+    user = "mlox_connector"
+    port = 0
+
+    def __init__(self) -> None:
+        self.is_connected = False
+
+    def open(self) -> "VirtualConnection":
+        self.is_connected = True
+        return self
+
+    def close(self) -> None:
+        self.is_connected = False
+
+    def __enter__(self) -> "VirtualConnection":
+        return self.open()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def run(
+        self, command: str, hide: bool = True, pty: bool = False
+    ) -> _VirtualCommandResult:
+        logger.debug("Ignoring virtual connector command: %s", command)
+        stdout = "ok\n" if command.strip() in {"echo ok", "true"} else ""
+        return _VirtualCommandResult(command, stdout=stdout)
+
+    def sudo(
+        self, command: str, hide: bool = True, pty: bool = False
+    ) -> _VirtualCommandResult:
+        return self.run(command, hide=hide, pty=pty)
+
+    def put(self, local: str | IO[bytes], remote: str) -> str:
+        logger.debug("Ignoring virtual connector put to %s", remote)
+        return remote
+
+    def get(self, remote: str, local: str | IO[bytes]) -> str | IO[bytes]:
+        logger.debug("Ignoring virtual connector get from %s", remote)
+        return local
+
+
+class VirtualServerConnection(ServerConnection):
+    """Context manager returning a :class:`VirtualConnection`."""
+
+    def __init__(self, connection: VirtualConnection):
+        self._connection = connection
+
+    def __enter__(self) -> VirtualConnection:
+        return self._connection.open()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._connection.close()
+
+
+@dataclass
+class VirtualConnectorServer(AbstractServer, AbstractConnectorServer):
+    """Virtual backend for externally hosted connector services."""
+
+    capabilities: ClassVar[set[ServerCapability]] = {ServerCapability.CONNECTOR}
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not self.ip:
+            self.ip = "connector.local"
+        self.port = "0"
+        self.backend = [ServerCapability.CONNECTOR.value]
+        self.mlox_user = MloxUser(
+            name=self.root or "mlox_connector",
+            pw="",
+            home="virtual://connector",
+            ssh_passphrase="",
+        )
+        self.state = "running"
+
+    def get_server_connection(
+        self, force_root: bool = False
+    ) -> VirtualServerConnection:
+        return VirtualServerConnection(VirtualConnection())
+
+    def test_connection(self) -> bool:
+        return True
+
+    def setup(self) -> None:
+        self.setup_backend()
+
+    def update(self) -> None:
+        logger.info("Skipping update for virtual connector server.")
+
+    def teardown(self) -> None:
+        self.teardown_backend()
+
+    def enable_debug_access(self) -> None:
+        logger.info("Debug access is not applicable to virtual connector servers.")
+
+    def disable_debug_access(self) -> None:
+        logger.info("Debug access is not applicable to virtual connector servers.")
+
+    def setup_backend(self) -> None:
+        self.state = "running"
+        self.backend = [ServerCapability.CONNECTOR.value]
+
+    def teardown_backend(self) -> None:
+        self.state = "shutdown"
+
+    def start_backend_runtime(self) -> None:
+        self.state = "running"
+
+    def stop_backend_runtime(self) -> None:
+        self.state = "shutdown"
+
+    def get_backend_status(self) -> dict[str, Any]:
+        return {
+            "backend.is_running": self.state == "running",
+            "backend.connector.virtual": True,
+        }
+
+    def get_server_info(self, no_cache: bool = False) -> dict[str, str | int | float]:
+        return {
+            "host": self.ip,
+            "cpu_count": 0,
+            "ram_gb": 0.0,
+            "storage_gb": 0.0,
+            "pretty_name": "Virtual connector backend",
+        }

--- a/mlox/servers/connector/virtual.py
+++ b/mlox/servers/connector/virtual.py
@@ -19,6 +19,7 @@ from mlox.server import (
     ServerCapability,
     ServerConnection,
 )
+from mlox.utils import generate_password
 
 logger = logging.getLogger(__name__)
 
@@ -41,11 +42,11 @@ class VirtualConnection:
     methods while avoiding any shell access to a real machine.
     """
 
-    host = "connector.local"
     user = "mlox_connector"
     port = 0
 
-    def __init__(self) -> None:
+    def __init__(self, host: str) -> None:
+        self.host = host
         self.is_connected = False
 
     def open(self) -> "VirtualConnection":
@@ -104,7 +105,7 @@ class VirtualConnectorServer(AbstractServer, AbstractConnectorServer):
     def __post_init__(self) -> None:
         super().__post_init__()
         if not self.ip:
-            self.ip = "connector.local"
+            self.ip = f"mlox-connector-{generate_password(8).lower()}"
         self.port = "0"
         self.backend = [ServerCapability.CONNECTOR.value]
         self.mlox_user = MloxUser(
@@ -118,7 +119,7 @@ class VirtualConnectorServer(AbstractServer, AbstractConnectorServer):
     def get_server_connection(
         self, force_root: bool = False
     ) -> VirtualServerConnection:
-        return VirtualServerConnection(VirtualConnection())
+        return VirtualServerConnection(VirtualConnection(self.ip))
 
     def test_connection(self) -> bool:
         return True

--- a/mlox/services/gcp/mlox.gcp.bigquery.yaml
+++ b/mlox/services/gcp/mlox.gcp.bigquery.yaml
@@ -23,9 +23,9 @@ links:
   documentation: https://cloud.google.com/bigquery
   changelog: https://cloud.google.com/bigquery
 requirements:
-  cpus: 1.0
-  ram_gb: 1.0
-  disk_gb: 1.0
+  cpus: 0.0
+  ram_gb: 0.0
+  disk_gb: 0.0
 groups:
   service: null
   cloud:
@@ -33,9 +33,6 @@ groups:
   database:
     warehouse: null
   backend:
-    kubernetes: null
-    docker: null
-    native: null
     connector: null
 capabilities:
   service:

--- a/mlox/services/gcp/mlox.gcp.secrets.yaml
+++ b/mlox/services/gcp/mlox.gcp.secrets.yaml
@@ -23,18 +23,15 @@ links:
   documentation: https://cloud.google.com/security/products/secret-manager
   changelog: https://cloud.google.com/security/products/secret-manager
 requirements:
-  cpus: 1.0
-  ram_gb: 1.0
-  disk_gb: 1.0
+  cpus: 0.0
+  ram_gb: 0.0
+  disk_gb: 0.0
 groups:
   service: null
   secret-manager: null
   cloud:
     gcp: null
   backend:
-    kubernetes: null
-    docker: null
-    native: null
     connector: null
 capabilities:
   service:

--- a/mlox/services/gcp/mlox.gcp.sheets.yaml
+++ b/mlox/services/gcp/mlox.gcp.sheets.yaml
@@ -17,9 +17,9 @@ links:
   documentation: https://workspace.google.com/intl/en_au/products/sheets/
   changelog: https://workspace.google.com/intl/en_au/products/sheets/
 requirements:
-  cpus: 1.0
-  ram_gb: 1.0
-  disk_gb: 1.0
+  cpus: 0.0
+  ram_gb: 0.0
+  disk_gb: 0.0
 groups:
   service: null
   cloud:
@@ -27,9 +27,6 @@ groups:
   database:
     spreadsheets: null
   backend:
-    kubernetes: null
-    docker: null
-    native: null
     connector: null
 capabilities:
   service:

--- a/mlox/services/gcp/mlox.gcp.storage.yaml
+++ b/mlox/services/gcp/mlox.gcp.storage.yaml
@@ -23,18 +23,15 @@ links:
   documentation: https://kubeapps.com/
   changelog: https://kubeapps.com/
 requirements:
-  cpus: 1.0
-  ram_gb: 1.0
-  disk_gb: 1.0
+  cpus: 0.0
+  ram_gb: 0.0
+  disk_gb: 0.0
 groups:
   service: null
   storage: null
   cloud:
     gcp: null
   backend:
-    kubernetes: null
-    docker: null
-    native: null
     connector: null
 capabilities:
   service:

--- a/mlox/ui/registry.py
+++ b/mlox/ui/registry.py
@@ -53,6 +53,7 @@ def _ensure_bootstrapped() -> None:
     for module_path, register_name in (
         ("mlox.view.services", "register_builtin_streamlit_services"),
         ("mlox.view.servers.ubuntu", "register_builtin_streamlit_servers"),
+        ("mlox.view.servers.connector", "register_builtin_streamlit_servers"),
         ("mlox.tui.services", "register_builtin_tui_services"),
     ):
         try:

--- a/mlox/view/servers/connector.py
+++ b/mlox/view/servers/connector.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import streamlit as st
+
+from mlox.config import ServiceConfig
+from mlox.infra import Infrastructure
+from mlox.ui.registry import register
+from mlox.utils import generate_password
+
+_REGISTERED = False
+
+
+def _generate_connector_name(infra: Infrastructure) -> str:
+    existing_names = {bundle.server.ip for bundle in infra.bundles}
+    while True:
+        name = f"mlox-connector-{generate_password(8).lower()}"
+        if name not in existing_names:
+            return name
+
+
+def setup(infra: Infrastructure, config: ServiceConfig) -> dict[str, Any] | None:
+    """Collect the logical name used to identify a virtual connector backend."""
+
+    connector_count = len(infra.filter_bundles_by_backend("connector"))
+    name = st.text_input(
+        "Connector name",
+        value=_generate_connector_name(infra),
+        help=(
+            "Unique logical name for this virtual backend. It is used for MLOX "
+            "lookups only and is not a hostname or IP address."
+        ),
+        key=f"setup-connector-name-{config.id}-{connector_count}",
+    ).strip()
+
+    if not name:
+        st.warning("Enter a connector name.")
+        return None
+    if infra.get_bundle_by_ip(name):
+        st.warning("A server with this name already exists.")
+        return None
+
+    return {"${MLOX_IP}": name}
+
+
+def register_builtin_streamlit_servers() -> None:
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    register(
+        config_id="connector-server",
+        frontend="streamlit",
+        function_name="setup",
+        handler=setup,
+    )
+    _REGISTERED = True

--- a/tests/unit/test_connector_server.py
+++ b/tests/unit/test_connector_server.py
@@ -2,11 +2,13 @@ from mlox.config import get_stacks_path, load_config
 from mlox.infra import Infrastructure
 from mlox.server import ServerCapability
 from mlox.servers.connector.virtual import VirtualConnectorServer
+from mlox.ui.registry import clear_handlers
+from mlox.view.servers import connector as connector_view
 
 
 def make_server() -> VirtualConnectorServer:
     return VirtualConnectorServer(
-        ip="connector.local",
+        ip="mlox-connector-test01",
         root="mlox_connector",
         root_pw="",
         service_config_id="connector-server",
@@ -21,7 +23,7 @@ def test_virtual_connector_server_has_no_physical_resources():
     assert server.state == "running"
     assert server.test_connection() is True
     assert server.get_server_info() == {
-        "host": "connector.local",
+        "host": "mlox-connector-test01",
         "cpu_count": 0,
         "ram_gb": 0.0,
         "storage_gb": 0.0,
@@ -49,11 +51,40 @@ def test_connector_server_config_can_be_added_and_filtered():
     assert config is not None
 
     infra = Infrastructure()
-    bundle = infra.add_server(config, {})
+    first_bundle = infra.add_server(config, {"${MLOX_IP}": "mlox-connector-first"})
+    second_bundle = infra.add_server(config, {"${MLOX_IP}": "mlox-connector-second"})
 
-    assert bundle is not None
-    assert isinstance(bundle.server, VirtualConnectorServer)
-    assert infra.filter_bundles_by_backend("connector") == [bundle]
+    assert first_bundle is not None
+    assert second_bundle is not None
+    assert isinstance(first_bundle.server, VirtualConnectorServer)
+    assert isinstance(second_bundle.server, VirtualConnectorServer)
+    assert infra.filter_bundles_by_backend("connector") == [
+        first_bundle,
+        second_bundle,
+    ]
+
+
+def test_connector_server_has_streamlit_setup_handler(monkeypatch):
+    clear_handlers()
+    monkeypatch.setattr(connector_view, "_REGISTERED", False)
+    monkeypatch.setattr(
+        connector_view.st,
+        "text_input",
+        lambda *args, **kwargs: "analytics-connectors",
+    )
+
+    config = load_config(
+        get_stacks_path(prefix="mlox-server"),
+        "/connector",
+        "mlox-server.connector.yaml",
+    )
+
+    assert config is not None
+    setup = config.get_ui_handler("streamlit", "setup")
+    assert callable(setup)
+    assert setup(Infrastructure(), config) == {"${MLOX_IP}": "analytics-connectors"}
+
+    clear_handlers()
 
 
 def test_connector_backend_lifecycle_is_virtual_and_idempotent():

--- a/tests/unit/test_connector_server.py
+++ b/tests/unit/test_connector_server.py
@@ -1,0 +1,74 @@
+from mlox.config import get_stacks_path, load_config
+from mlox.infra import Infrastructure
+from mlox.server import ServerCapability
+from mlox.servers.connector.virtual import VirtualConnectorServer
+
+
+def make_server() -> VirtualConnectorServer:
+    return VirtualConnectorServer(
+        ip="connector.local",
+        root="mlox_connector",
+        root_pw="",
+        service_config_id="connector-server",
+    )
+
+
+def test_virtual_connector_server_has_no_physical_resources():
+    server = make_server()
+
+    assert server.capabilities == {ServerCapability.CONNECTOR}
+    assert server.backend == ["connector"]
+    assert server.state == "running"
+    assert server.test_connection() is True
+    assert server.get_server_info() == {
+        "host": "connector.local",
+        "cpu_count": 0,
+        "ram_gb": 0.0,
+        "storage_gb": 0.0,
+        "pretty_name": "Virtual connector backend",
+    }
+
+
+def test_virtual_connection_supports_connector_service_lifecycle_shape():
+    server = make_server()
+
+    with server.get_server_connection() as connection:
+        assert connection.is_connected is True
+        assert connection.run("true").ok is True
+        assert connection.run("echo ok").stdout == "ok\n"
+
+    assert connection.is_connected is False
+
+
+def test_connector_server_config_can_be_added_and_filtered():
+    config = load_config(
+        get_stacks_path(prefix="mlox-server"),
+        "/connector",
+        "mlox-server.connector.yaml",
+    )
+    assert config is not None
+
+    infra = Infrastructure()
+    bundle = infra.add_server(config, {})
+
+    assert bundle is not None
+    assert isinstance(bundle.server, VirtualConnectorServer)
+    assert infra.filter_bundles_by_backend("connector") == [bundle]
+
+
+def test_connector_backend_lifecycle_is_virtual_and_idempotent():
+    server = make_server()
+
+    server.stop_backend_runtime()
+    assert server.get_backend_status() == {
+        "backend.is_running": False,
+        "backend.connector.virtual": True,
+    }
+
+    server.start_backend_runtime()
+    assert server.get_backend_status()["backend.is_running"] is True
+
+    server.teardown()
+    assert server.state == "shutdown"
+    server.setup()
+    assert server.state == "running"

--- a/tests/unit/test_server_configs.py
+++ b/tests/unit/test_server_configs.py
@@ -317,6 +317,7 @@ def test_builtin_server_config_capabilities_match_classes():
     by_id = {config.id: config for config in configs}
     expected = {
         "local-server": ({"git"}, {"local"}),
+        "connector-server": (set(), {"connector"}),
         "ubuntu-simple-24.04-server": (set(), {"native"}),
         "ubuntu-native-24.04-server": (
             {"git", "firewall", "initial_auth_password"},

--- a/tests/unit/test_service_configs.py
+++ b/tests/unit/test_service_configs.py
@@ -291,3 +291,28 @@ def test_builtin_service_configs_have_matching_explicit_capabilities():
             for capability in getattr(service_class, "capabilities", set())
         }
         assert config.service_capabilities() <= class_capabilities, config.path
+
+
+@pytest.mark.parametrize(
+    "config_id",
+    [
+        "gcp-bigquery-0.1.0",
+        "gcp-secret-manager-0.1.0",
+        "gcp-sheets-0.1.0",
+        "gcp-storage-0.1.0",
+    ],
+)
+def test_externally_hosted_gcp_services_use_connector_backend(config_id):
+    configs = {
+        config.id: config for config in load_all_service_configs(include_plugins=False)
+    }
+
+    config = configs[config_id]
+
+    assert config.backend_capabilities() == {"connector"}
+    assert set(config.groups["backend"]) == {"connector"}
+    assert config.requirements == {
+        "cpus": 0.0,
+        "ram_gb": 0.0,
+        "disk_gb": 0.0,
+    }


### PR DESCRIPTION
### Motivation
- Introduce a lightweight virtual server backend for externally hosted connector-style services (eg. GCP Secret Manager, Sheets, BigQuery) so they can be represented in MLOX without provisioning physical compute resources.
- Make service configs for externally hosted GCP services declare a `connector` backend and zero resource requirements to avoid misleading resource expectations.
- Ensure infra and capability validation, filtering, and tests are aware of the new `connector` server capability.

### Description
- Add `ServerCapability.CONNECTOR` and `AbstractConnectorServer` to `mlox.server` and wire it into `mlox.config` via `SERVER_CAPABILITY_ABCS`.
- Implement a new virtual connector backend at `mlox.servers.connector.virtual.VirtualConnectorServer` with a no-op `VirtualConnection` and `VirtualServerConnection` context manager to satisfy lifecycle shapes without real runtime resources.
- Add package entry `mlox.servers.connector.__init__` and a server manifest `mlox/servers/connector/mlox-server.connector.yaml` registering the new backend.
- Update multiple GCP service stack YAMLs to use `connector` backend and set `requirements` CPU/RAM/DISK to `0.0` for externally hosted services.
- Extend `Infrastructure.filter_bundles_by_backend` to accept `connector` among allowed backends.
- Add unit tests in `tests/unit/test_connector_server.py` and extend existing config tests to expect the `connector-server` and GCP services behavior.

### Testing
- Ran unit tests for the server and service config areas via `pytest tests/unit -q` including `test_connector_server.py`, relevant `test_server_configs.py`, and `test_service_configs.py` assertions.
- All added and updated unit tests completed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2580a478008322b16c5c047b5bd722)