### PR TITLE
feat(services): add Kubeflow Kubernetes service with Traefik ingress

### DIFF
--- a/mlox/services/kubeflow/__init__.py
+++ b/mlox/services/kubeflow/__init__.py
@@ -1,0 +1,1 @@
+"""Kubeflow service integration."""

--- a/mlox/services/kubeflow/k8s.py
+++ b/mlox/services/kubeflow/k8s.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import secrets
 import shlex
 from dataclasses import dataclass
 from typing import Dict
@@ -20,8 +21,19 @@ class KubeflowService(AbstractService):
     ingress_namespace: str = "istio-system"
     ingress_name: str = "kubeflow"
     ingress_service: str = "istio-ingressgateway"
-    ingress_port: int = 80
+    ingress_port: int = 8443
+    traefik_namespace: str = "kubeflow-traefik"
+    traefik_release: str = "kubeflow-traefik"
+    traefik_chart_version: str = "34.4.1"
+    minio_image: str = (
+        "docker.io/minio/minio:RELEASE.2019-08-14T20-37-41Z"
+    )
+    dex_email: str = "user@example.com"
+    dex_password: str = "12341234"
     install_attempts: int = 3
+    webhook_ready_timeout_seconds: int = 120
+    pipeline_ready_timeout_seconds: int = 300
+    teardown_timeout_seconds: int = 120
 
     @property
     def manifests_url(self) -> str:
@@ -36,30 +48,51 @@ class KubeflowService(AbstractService):
             self.state = "unknown"
             return
 
-        ingress_path = self._write_ingress_manifest(conn)
-        result = self.exec.k8s_apply_manifest(
-            conn,
-            ingress_path,
-            namespace=self.ingress_namespace,
-            kubeconfig=self.kubeconfig,
-        )
-        if result is None:
-            logger.error("Failed to configure the Kubeflow Traefik ingress.")
+        if not self._repair_pipeline_storage(conn):
+            logger.error("Failed to configure the Kubeflow Pipelines object store.")
+            self.state = "unknown"
+            return
+
+        if not self._wait_for_pipeline_services(conn):
+            logger.error("Kubeflow Pipelines did not become ready.")
+            self.state = "unknown"
+            return
+
+        if not self._refresh_authentication(conn):
+            logger.error("Failed to synchronize Kubeflow authentication.")
+            self.state = "unknown"
+            return
+
+        if not self._configure_jupyter_cookies(conn):
+            logger.error("Failed to configure secure Kubeflow Jupyter cookies.")
+            self.state = "unknown"
+            return
+
+        self._remove_legacy_ingress_resources(conn)
+        traefik_values_path = self._write_traefik_values(conn)
+        if not self._install_dedicated_traefik(conn, traefik_values_path):
+            logger.error("Failed to install the dedicated Kubeflow Traefik ingress.")
             self.state = "unknown"
             return
 
         self.service_ports["Kubeflow"] = self.ingress_port
-        self.service_urls["Kubeflow"] = f"http://{conn.host}:{self.ingress_port}/"
+        self.service_urls["Kubeflow"] = f"https://{conn.host}:{self.ingress_port}/"
         self.state = "running"
 
     def teardown(self, conn) -> None:
         logger.info("🗑️ Uninstalling Kubeflow")
-        self.exec.k8s_delete_resource(
+        delete_args = [
+            "--wait=false",
+            f"--request-timeout={self.teardown_timeout_seconds}s",
+        ]
+        self._remove_legacy_ingress_resources(conn, extra_args=delete_args)
+        self.exec.helm_uninstall(
             conn,
-            "ingress",
-            self.ingress_name,
-            namespace=self.ingress_namespace,
+            release=self.traefik_release,
+            namespace=self.traefik_namespace,
             kubeconfig=self.kubeconfig,
+            extra_args=[f"--timeout={self.teardown_timeout_seconds}s"],
+            ignore_missing=True,
         )
         self._run_kustomize(conn, "delete", ignore_not_found=True)
         self.exec.fs_delete_dir(conn, self.target_path)
@@ -121,21 +154,190 @@ class KubeflowService(AbstractService):
         }
 
     def get_secrets(self) -> Dict[str, Dict]:
-        return {}
+        return {
+            "kubeflow_dex_credentials": {
+                "email": self.dex_email,
+                "password": self.dex_password,
+                "service_url": self.service_urls.get("Kubeflow", ""),
+            }
+        }
 
     def _apply_kubeflow_manifests(self, conn) -> bool:
         # The upstream manifests contain CRDs and resources that depend on those
-        # CRDs. Retrying the idempotent apply handles API discovery propagation.
+        # CRDs. Server-side apply avoids oversized last-applied annotations on
+        # large CRDs, and retries handle API discovery propagation.
         for attempt in range(1, self.install_attempts + 1):
             result = self._run_kustomize(conn, "apply")
             if result is not None:
                 return True
-            logger.warning(
-                "Kubeflow manifest apply attempt %s/%s failed; retrying.",
-                attempt,
-                self.install_attempts,
-            )
+            if attempt < self.install_attempts:
+                logger.warning(
+                    "Kubeflow manifest apply attempt %s/%s failed; waiting "
+                    "for admission webhooks before retrying.",
+                    attempt,
+                    self.install_attempts,
+                )
+                self._wait_for_admission_webhooks(conn)
         return False
+
+    def _wait_for_admission_webhooks(self, conn) -> None:
+        # A partial apply can register admission configurations before their
+        # backing deployments have endpoints. Wait for all known blockers
+        # before retrying the full manifest set.
+        for namespace, deployment, description in (
+            (
+                "knative-serving",
+                "deployment/webhook",
+                "Wait for the Knative admission webhook",
+            ),
+            (
+                "kubeflow",
+                "deployment/kserve-controller-manager",
+                "Wait for the KServe admission webhook",
+            ),
+        ):
+            self._rollout_status(
+                conn,
+                namespace,
+                deployment,
+                description,
+            )
+
+    def _refresh_authentication(self, conn) -> bool:
+        if not self._rollout_status(
+            conn,
+            "auth",
+            "deployment/dex",
+            "Wait for Dex",
+        ):
+            return False
+
+        command = self._kubectl_command(
+            "-n",
+            "oauth2-proxy",
+            "set",
+            "env",
+            "deployment/oauth2-proxy",
+            f"OAUTH2_PROXY_COOKIE_SECRET={secrets.token_hex(16)}",
+        )
+        result = self.exec.execute(
+            conn,
+            command,
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Rotate the OAuth2 Proxy session key",
+        )
+        if result is None:
+            return False
+
+        command = self._kubectl_command(
+            "-n",
+            "istio-system",
+            "rollout",
+            "restart",
+            "deployment/istiod",
+        )
+        result = self.exec.execute(
+            conn,
+            command,
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Restart deployment/istiod",
+        )
+        if result is None:
+            return False
+
+        return self._rollout_status(
+            conn,
+            "oauth2-proxy",
+            "deployment/oauth2-proxy",
+            "Wait for OAuth2 Proxy",
+        ) and self._rollout_status(
+            conn,
+            "istio-system",
+            "deployment/istiod",
+            "Wait for Istio",
+        )
+
+    def _repair_pipeline_storage(self, conn) -> bool:
+        command = self._kubectl_command(
+            "-n",
+            "kubeflow",
+            "set",
+            "image",
+            "deployment/minio",
+            f"minio={self.minio_image}",
+        )
+        result = self.exec.execute(
+            conn,
+            command,
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Use the supported MinIO image for Kubeflow Pipelines",
+        )
+        return result is not None
+
+    def _wait_for_pipeline_services(self, conn) -> bool:
+        for resource, description in (
+            ("deployment/mysql", "Wait for the Kubeflow Pipelines database"),
+            ("deployment/minio", "Wait for the Kubeflow Pipelines object store"),
+            ("deployment/ml-pipeline", "Wait for the Kubeflow Pipelines API"),
+            ("deployment/ml-pipeline-ui", "Wait for the Kubeflow Pipelines UI"),
+        ):
+            if not self._rollout_status(
+                conn,
+                "kubeflow",
+                resource,
+                description,
+                timeout_seconds=self.pipeline_ready_timeout_seconds,
+            ):
+                return False
+        return True
+
+    def _rollout_status(
+        self,
+        conn,
+        namespace: str,
+        resource: str,
+        description: str,
+        *,
+        timeout_seconds: int | None = None,
+    ) -> bool:
+        timeout = timeout_seconds or self.webhook_ready_timeout_seconds
+        command = self._kubectl_command(
+            "-n",
+            namespace,
+            "rollout",
+            "status",
+            resource,
+            f"--timeout={timeout}s",
+        )
+        result = self.exec.execute(
+            conn,
+            command,
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description=description,
+        )
+        return result is not None
+
+    def _configure_jupyter_cookies(self, conn) -> bool:
+        command = self._kubectl_command(
+            "-n",
+            "kubeflow",
+            "set",
+            "env",
+            "deployment/jupyter-web-app-deployment",
+            "APP_SECURE_COOKIES=true",
+        )
+        result = self.exec.execute(
+            conn,
+            command,
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Configure secure Jupyter cookies",
+        )
+        return result is not None
 
     def _run_kustomize(
         self,
@@ -144,12 +346,32 @@ class KubeflowService(AbstractService):
         *,
         ignore_not_found: bool = False,
     ) -> str | None:
-        args = [action, "-k", self.manifests_url]
+        args = [action]
+        if action == "apply":
+            args.extend(["--server-side", "--force-conflicts"])
+        elif action == "delete":
+            args.extend(
+                [
+                    "--wait=false",
+                    f"--request-timeout={self.teardown_timeout_seconds}s",
+                ]
+            )
+        args.extend(["-k", self.manifests_url])
         if ignore_not_found:
             args.append("--ignore-not-found")
+        command = self._kubectl_command(*args)
+        if action == "delete":
+            command = shlex.join(
+                [
+                    "timeout",
+                    "--signal=TERM",
+                    "--kill-after=10s",
+                    f"{self.teardown_timeout_seconds}s",
+                ]
+            ) + f" {command}"
         return self.exec.execute(
             conn,
-            self._kubectl_command(*args),
+            command,
             group=TaskGroup.KUBERNETES,
             sudo=True,
             description=f"{action.title()} Kubeflow manifests",
@@ -158,28 +380,99 @@ class KubeflowService(AbstractService):
     def _kubectl_command(self, *args: str) -> str:
         return shlex.join(["kubectl", "--kubeconfig", self.kubeconfig, *args])
 
-    def _write_ingress_manifest(self, conn) -> str:
-        manifest_path = f"{self.target_path}/{self.ingress_name}-ingress.yaml"
-        manifest = f"""apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {self.ingress_name}
-  namespace: {self.ingress_namespace}
-  annotations:
-    kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.entrypoints: web
-spec:
-  ingressClassName: traefik
-  rules:
-    - http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {self.ingress_service}
-                port:
-                  number: 80
+    def _remove_legacy_ingress_resources(
+        self,
+        conn,
+        *,
+        extra_args: list[str] | None = None,
+    ) -> None:
+        delete_args = extra_args or [
+            "--wait=false",
+            f"--request-timeout={self.teardown_timeout_seconds}s",
+        ]
+        for resource_type, name in (
+            ("ingress", self.ingress_name),
+            ("ingress", f"{self.ingress_name}-entry"),
+            ("ingress", f"{self.ingress_name}-routes"),
+            ("middleware", f"{self.ingress_name}-auth-redirect"),
+            ("middleware", f"{self.ingress_name}-strip-prefix"),
+        ):
+            self.exec.k8s_delete_resource(
+                conn,
+                resource_type,
+                name,
+                namespace=self.ingress_namespace,
+                kubeconfig=self.kubeconfig,
+                extra_args=delete_args,
+            )
+
+    def _write_traefik_values(self, conn) -> str:
+        values_path = f"{self.target_path}/kubeflow-traefik-values.yaml"
+        values = f"""ingressClass:
+  enabled: false
+gateway:
+  enabled: false
+providers:
+  kubernetesCRD:
+    enabled: false
+  kubernetesIngress:
+    enabled: false
+  file:
+    enabled: true
+    content: |-
+      http:
+        routers:
+          kubeflow:
+            entryPoints:
+              - websecure
+            rule: PathPrefix(`/`)
+            service: kubeflow
+            tls: {{}}
+        services:
+          kubeflow:
+            loadBalancer:
+              servers:
+                - url: http://{self.ingress_service}.{self.ingress_namespace}.svc.cluster.local:80
+ports:
+  web:
+    expose:
+      default: false
+  websecure:
+    port: {self.ingress_port}
+    exposedPort: {self.ingress_port}
+    expose:
+      default: true
+service:
+  type: LoadBalancer
 """
-        self.exec.fs_write_file(conn, manifest_path, manifest)
-        return manifest_path
+        self.exec.fs_write_file(conn, values_path, values)
+        return values_path
+
+    def _install_dedicated_traefik(self, conn, values_path: str) -> bool:
+        repo_result = self.exec.helm_repo_add(
+            conn,
+            "kubeflow-traefik",
+            "https://traefik.github.io/charts",
+            kubeconfig=self.kubeconfig,
+        )
+        if repo_result is None:
+            return False
+
+        result = self.exec.helm_upgrade_install(
+            conn,
+            release=self.traefik_release,
+            chart="kubeflow-traefik/traefik",
+            namespace=self.traefik_namespace,
+            kubeconfig=self.kubeconfig,
+            create_namespace=True,
+            extra_args=[
+                "--version",
+                self.traefik_chart_version,
+                "-f",
+                values_path,
+                "--wait",
+                "--timeout",
+                "5m",
+            ],
+        )
+        return result is not None

--- a/mlox/services/kubeflow/k8s.py
+++ b/mlox/services/kubeflow/k8s.py
@@ -1,0 +1,185 @@
+import json
+import logging
+import shlex
+from dataclasses import dataclass
+from typing import Dict
+
+from mlox.executors import TaskGroup
+from mlox.service import AbstractService, ServiceCapability
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class KubeflowService(AbstractService):
+    """Install the upstream Kubeflow manifests on a Kubernetes cluster."""
+
+    capabilities = {ServiceCapability.DASHBOARD}
+    version: str = "v1.10.1"
+    kubeconfig: str = "/etc/rancher/k3s/k3s.yaml"
+    ingress_namespace: str = "istio-system"
+    ingress_name: str = "kubeflow"
+    ingress_service: str = "istio-ingressgateway"
+    ingress_port: int = 80
+    install_attempts: int = 3
+
+    @property
+    def manifests_url(self) -> str:
+        return f"https://github.com/kubeflow/manifests/example?ref={self.version}"
+
+    def setup(self, conn) -> None:
+        logger.info("🔧 Installing Kubeflow %s", self.version)
+        self.exec.fs_create_dir(conn, self.target_path)
+
+        if not self._apply_kubeflow_manifests(conn):
+            logger.error("Failed to apply the Kubeflow manifests.")
+            self.state = "unknown"
+            return
+
+        ingress_path = self._write_ingress_manifest(conn)
+        result = self.exec.k8s_apply_manifest(
+            conn,
+            ingress_path,
+            namespace=self.ingress_namespace,
+            kubeconfig=self.kubeconfig,
+        )
+        if result is None:
+            logger.error("Failed to configure the Kubeflow Traefik ingress.")
+            self.state = "unknown"
+            return
+
+        self.service_ports["Kubeflow"] = self.ingress_port
+        self.service_urls["Kubeflow"] = f"http://{conn.host}:{self.ingress_port}/"
+        self.state = "running"
+
+    def teardown(self, conn) -> None:
+        logger.info("🗑️ Uninstalling Kubeflow")
+        self.exec.k8s_delete_resource(
+            conn,
+            "ingress",
+            self.ingress_name,
+            namespace=self.ingress_namespace,
+            kubeconfig=self.kubeconfig,
+        )
+        self._run_kustomize(conn, "delete", ignore_not_found=True)
+        self.exec.fs_delete_dir(conn, self.target_path)
+        self.service_ports.clear()
+        self.service_urls.clear()
+        self.state = "un-initialized"
+
+    def spin_up(self, conn) -> bool:
+        return self.state == "running"
+
+    def spin_down(self, conn) -> bool:
+        logger.info("Kubeflow workloads are managed by Kubernetes.")
+        return True
+
+    def check(self, conn) -> Dict:
+        command = self._kubectl_command(
+            "-n",
+            "kubeflow",
+            "get",
+            "deployment",
+            "centraldashboard",
+            "-o",
+            "json",
+        )
+        result = self.exec.execute(
+            conn,
+            command,
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Check the Kubeflow central dashboard",
+        )
+        if not result:
+            return {
+                "status": "unknown",
+                "details": "Kubeflow central dashboard was not found.",
+            }
+
+        try:
+            deployment = json.loads(result)
+        except json.JSONDecodeError:
+            return {
+                "status": "unknown",
+                "details": "Failed to parse the Kubeflow deployment status.",
+            }
+
+        desired = deployment.get("spec", {}).get("replicas", 1)
+        available = deployment.get("status", {}).get("availableReplicas", 0)
+        if desired > 0 and available >= desired:
+            return {
+                "status": "running",
+                "details": "Kubeflow central dashboard is available.",
+            }
+        return {
+            "status": "starting",
+            "details": (
+                f"Kubeflow central dashboard has {available}/{desired} "
+                "available replicas."
+            ),
+        }
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}
+
+    def _apply_kubeflow_manifests(self, conn) -> bool:
+        # The upstream manifests contain CRDs and resources that depend on those
+        # CRDs. Retrying the idempotent apply handles API discovery propagation.
+        for attempt in range(1, self.install_attempts + 1):
+            result = self._run_kustomize(conn, "apply")
+            if result is not None:
+                return True
+            logger.warning(
+                "Kubeflow manifest apply attempt %s/%s failed; retrying.",
+                attempt,
+                self.install_attempts,
+            )
+        return False
+
+    def _run_kustomize(
+        self,
+        conn,
+        action: str,
+        *,
+        ignore_not_found: bool = False,
+    ) -> str | None:
+        args = [action, "-k", self.manifests_url]
+        if ignore_not_found:
+            args.append("--ignore-not-found")
+        return self.exec.execute(
+            conn,
+            self._kubectl_command(*args),
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description=f"{action.title()} Kubeflow manifests",
+        )
+
+    def _kubectl_command(self, *args: str) -> str:
+        return shlex.join(["kubectl", "--kubeconfig", self.kubeconfig, *args])
+
+    def _write_ingress_manifest(self, conn) -> str:
+        manifest_path = f"{self.target_path}/{self.ingress_name}-ingress.yaml"
+        manifest = f"""apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {self.ingress_name}
+  namespace: {self.ingress_namespace}
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: web
+spec:
+  ingressClassName: traefik
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {self.ingress_service}
+                port:
+                  number: 80
+"""
+        self.exec.fs_write_file(conn, manifest_path, manifest)
+        return manifest_path

--- a/mlox/services/kubeflow/mlox.kubeflow.yaml
+++ b/mlox/services/kubeflow/mlox.kubeflow.yaml
@@ -28,7 +28,7 @@ capabilities:
   backend:
     - kubernetes
 ports:
-  web_ui: 80
+  web_ui: 8443
 build:
   class_name: mlox.services.kubeflow.k8s.KubeflowService
   params:

--- a/mlox/services/kubeflow/mlox.kubeflow.yaml
+++ b/mlox/services/kubeflow/mlox.kubeflow.yaml
@@ -1,0 +1,37 @@
+id: kubeflow-1.10.1-k3s
+name: Kubeflow
+version: 1.10.1
+maintainer: Kubeflow Community
+description_short: A Kubernetes-native platform for machine learning workflows.
+description: >-
+  Kubeflow provides notebooks, pipelines, model serving, training operators, and
+  a central dashboard for running machine learning workloads on Kubernetes. This
+  service installs the upstream Kubeflow manifests and exposes the Istio gateway
+  through the Traefik ingress controller included with k3s.
+links:
+  project: https://www.kubeflow.org/
+  documentation: https://www.kubeflow.org/docs/
+  changelog: https://github.com/kubeflow/manifests/releases
+  security: https://github.com/kubeflow/manifests/security
+requirements:
+  cpus: 8.0
+  ram_gb: 16.0
+  disk_gb: 50.0
+groups:
+  service: null
+  machine-learning: null
+  backend:
+    kubernetes: null
+capabilities:
+  service:
+    - dashboard
+  backend:
+    - kubernetes
+ports:
+  web_ui: 80
+build:
+  class_name: mlox.services.kubeflow.k8s.KubeflowService
+  params:
+    name: kubeflow
+    template: ${MLOX_STACKS_PATH}/kubeflow/kubeflow.yaml
+    target_path: ${MLOX_USER_HOME}/kubeflow-1.10.1

--- a/mlox/services/mlflow_gateway/README.md
+++ b/mlox/services/mlflow_gateway/README.md
@@ -1,0 +1,94 @@
+# MLflow Gateway
+
+MLflow Gateway provides a Basic Auth protected HTTPS API for loading and invoking
+MLflow registry models. Models are loaded on demand and cached in memory.
+
+## Setup
+
+In MLOX, add an MLflow model registry first, then select one gateway service:
+
+- `mlflow-gateway-3.8.1-docker`
+- `mlflow-gateway-3.8.1-k3s`
+
+During setup, select the registry and optionally configure additional Python
+requirements, the maximum cached models, and the cache TTL.
+
+MLOX generates the external port and gateway credentials. Both are shown on the
+service settings page.
+
+## Usage
+
+Health check:
+
+```bash
+curl -k -u 'USER:PASSWORD' https://HOST:PORT/health
+```
+
+Invoke a registered model version:
+
+```bash
+curl -k -u 'USER:PASSWORD' \
+  https://HOST:PORT/prod/predict \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "registry_model_name": "MyModel",
+    "registry_model_version": "1",
+    "input_data": [[1, 2, 3]],
+    "params": {}
+  }'
+```
+
+The API also supports model aliases and cache inspection at `/cache`.
+
+## Docker
+
+The Docker service builds the gateway image locally and starts a dedicated
+Traefik container on an automatically assigned MLOX port.
+
+Advantages:
+
+- Fast restarts after the image has been built.
+- Simple lifecycle through Docker Compose.
+- Isolated network and Traefik instance per gateway.
+
+Pitfalls:
+
+- Requires Docker and local image build capacity.
+- Additional requirements trigger an image rebuild.
+- Traefik mounts the Docker socket read-only.
+
+## Kubernetes / k3s
+
+The k3s service creates an isolated namespace containing a ConfigMap, Secret,
+single-replica Deployment, and ClusterIP Service. It installs a dedicated pinned
+Traefik Helm release for that gateway. It does **not** use k3s's default Traefik.
+
+MLOX assigns the external port through `${MLOX_AUTO_PORT_REST}` and configures
+Traefik to expose it. Kubernetes does not choose this port automatically. A
+second gateway receives another available MLOX port and its own namespace and
+Traefik release.
+
+Advantages:
+
+- Kubernetes-native readiness, health checks, and workload recovery.
+- Each gateway is isolated from the default ingress and other gateways.
+- No container registry or custom image publication is required.
+
+Pitfalls:
+
+- The pod installs MLflow and other dependencies from PyPI at startup, so the
+  first start and pod replacements are slower and require outbound access.
+- Helm must reach the Traefik chart repository.
+- The external port must be allowed by the host firewall.
+- Credentials are stored in a Kubernetes Secret; protect cluster access.
+
+## Common Limitations
+
+- TLS uses Traefik's default self-signed certificate. Use `curl -k` or
+  `verify=False`, or install trusted certificate handling separately.
+- MLflow tracking TLS verification is disabled for compatibility with MLOX's
+  self-signed deployments.
+- The model cache is process-local and is cleared on restart.
+- Both variants use one gateway process/replica; shared caching, HPA, and
+  high-availability operation are not provided.
+- Model-specific libraries must be included under additional requirements.

--- a/mlox/services/mlflow_gateway/__init__.py
+++ b/mlox/services/mlflow_gateway/__init__.py
@@ -1,5 +1,6 @@
 """Lightweight MLflow registry gateway service."""
 
 from .docker import MLFlowGatewayDockerService
+from .k3s import MLFlowGatewayK3sService
 
-__all__ = ["MLFlowGatewayDockerService"]
+__all__ = ["MLFlowGatewayDockerService", "MLFlowGatewayK3sService"]

--- a/mlox/services/mlflow_gateway/k3s.py
+++ b/mlox/services/mlflow_gateway/k3s.py
@@ -1,0 +1,389 @@
+import json
+import logging
+import shlex
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from passlib.hash import apr_md5_crypt
+
+from mlox.executors import TaskGroup
+from mlox.services.mlflow_gateway.docker import (
+    MLFlowGatewayDockerService,
+    _resolved_setting,
+    _resolved_text,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MLFlowGatewayK3sService(MLFlowGatewayDockerService):
+    kubeconfig: str = "/etc/rancher/k3s/k3s.yaml"
+    container_port: int = 8080
+    rollout_timeout_seconds: int = 600
+    teardown_timeout_seconds: int = 120
+    traefik_chart_version: str = "34.4.1"
+    namespace: str = field(init=False)
+    deployment_name: str = field(init=False, default="mlflow-gateway")
+    service_name: str = field(init=False, default="mlflow-gateway")
+    traefik_release: str = field(init=False, default="mlflow-gateway-traefik")
+    manifest_path: str = field(init=False)
+    traefik_values_path: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.namespace = f"mlflow-gateway-{self.port}"
+        self.manifest_path = f"{self.target_path}/mlflow-gateway.yaml"
+        self.traefik_values_path = f"{self.target_path}/traefik-values.yaml"
+
+    @staticmethod
+    def _yaml_string(value: str) -> str:
+        return json.dumps(value)
+
+    @staticmethod
+    def _config_map_block(value: str) -> str:
+        return textwrap.indent(value.rstrip(), "    ")
+
+    def _render_gateway_manifest(self) -> str:
+        serve_script = Path(self.serve_script).read_text(encoding="utf-8")
+        requirements = _resolved_text(self.requirements_txt)
+        cache_size = _resolved_setting(self.cache_max_models, "10")
+        cache_ttl = _resolved_setting(self.cache_ttl_days, "10")
+
+        return f"""apiVersion: v1
+kind: Namespace
+metadata:
+  name: {self.namespace}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlflow-gateway-code
+  namespace: {self.namespace}
+data:
+  serve.py: |-
+{self._config_map_block(serve_script)}
+  gateway-requirements.txt: |-
+{self._config_map_block(requirements)}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlflow-gateway-credentials
+  namespace: {self.namespace}
+type: Opaque
+stringData:
+  gateway-user: {self._yaml_string(self.user)}
+  gateway-password: {self._yaml_string(self.pw)}
+  tracking-uri: {self._yaml_string(self.tracking_uri)}
+  tracking-user: {self._yaml_string(self.tracking_user)}
+  tracking-password: {self._yaml_string(self.tracking_pw)}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {self.deployment_name}
+  namespace: {self.namespace}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mlflow-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mlflow-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: python:3.12-slim
+          imagePullPolicy: IfNotPresent
+          workingDir: /app
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              pip install --no-cache-dir \
+                "mlflow==3.8.1" \
+                "mlflow[extras]==3.8.1" \
+                "fastapi==0.115.0" \
+                "uvicorn[standard]==0.30.6" \
+                "pandas>=2.2" \
+                "numpy>=1.26"
+              if [ -s /app/gateway-requirements.txt ]; then
+                pip install --no-cache-dir -r /app/gateway-requirements.txt
+              fi
+              exec uvicorn serve:app --host 0.0.0.0 --port {self.container_port}
+          env:
+            - name: MLFLOW_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-uri
+            - name: MLFLOW_TRACKING_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-uri
+            - name: MLFLOW_TRACKING_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-user
+            - name: MLFLOW_TRACKING_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-password
+            - name: MLFLOW_TRACKING_INSECURE_TLS
+              value: "true"
+            - name: MLOX_GATEWAY_CACHE_MAX_MODELS
+              value: {self._yaml_string(cache_size)}
+            - name: MLOX_GATEWAY_CACHE_TTL_DAYS
+              value: {self._yaml_string(cache_ttl)}
+          ports:
+            - name: http
+              containerPort: {self.container_port}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 6
+          volumeMounts:
+            - name: gateway-code
+              mountPath: /app/serve.py
+              subPath: serve.py
+              readOnly: true
+            - name: gateway-code
+              mountPath: /app/gateway-requirements.txt
+              subPath: gateway-requirements.txt
+              readOnly: true
+      volumes:
+        - name: gateway-code
+          configMap:
+            name: mlflow-gateway-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {self.service_name}
+  namespace: {self.namespace}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mlflow-gateway
+  ports:
+    - name: http
+      port: {self.container_port}
+      targetPort: http
+"""
+
+    def _render_traefik_values(self) -> str:
+        password_hash = apr_md5_crypt.hash(self.pw)
+        auth_user = self._yaml_string(f"{self.user}:{password_hash}")
+        backend_url = (
+            f"http://{self.service_name}.{self.namespace}.svc.cluster.local:"
+            f"{self.container_port}"
+        )
+
+        return f"""deployment:
+  replicas: 1
+ingressClass:
+  enabled: false
+providers:
+  kubernetesCRD:
+    enabled: false
+  kubernetesIngress:
+    enabled: false
+  file:
+    enabled: true
+    watch: true
+    content: |-
+      http:
+        routers:
+          gateway:
+            entryPoints:
+              - websecure
+            rule: PathPrefix(`/`)
+            service: gateway
+            middlewares:
+              - gateway-auth
+            tls: {{}}
+        middlewares:
+          gateway-auth:
+            basicAuth:
+              users:
+                - {auth_user}
+        services:
+          gateway:
+            loadBalancer:
+              servers:
+                - url: {self._yaml_string(backend_url)}
+ports:
+  web:
+    expose:
+      default: false
+  websecure:
+    port: 8443
+    exposedPort: {self.port}
+    expose:
+      default: true
+service:
+  type: LoadBalancer
+"""
+
+    def _kubectl(self, arguments: str) -> str:
+        return f"kubectl --kubeconfig {shlex.quote(self.kubeconfig)} {arguments}"
+
+    def setup(self, conn) -> None:
+        self.exec.fs_create_dir(conn, self.target_path)
+        self.exec.fs_write_file(
+            conn, self.manifest_path, self._render_gateway_manifest()
+        )
+        self.exec.fs_write_file(
+            conn, self.traefik_values_path, self._render_traefik_values()
+        )
+
+        if (
+            self.exec.k8s_apply_manifest(
+                conn, self.manifest_path, kubeconfig=self.kubeconfig
+            )
+            is None
+        ):
+            logger.error("Failed to apply the MLflow Gateway Kubernetes manifest.")
+            self.state = "unknown"
+            return
+
+        rollout = self.exec.execute(
+            conn,
+            self._kubectl(
+                f"rollout status deployment/{self.deployment_name} "
+                f"--namespace {self.namespace} "
+                f"--timeout={self.rollout_timeout_seconds}s"
+            ),
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Wait for the MLflow Gateway deployment",
+        )
+        if rollout is None:
+            logger.error("MLflow Gateway deployment did not become ready.")
+            self.state = "unknown"
+            return
+
+        if (
+            self.exec.helm_repo_add(
+                conn,
+                "mlflow-gateway-traefik",
+                "https://traefik.github.io/charts",
+                kubeconfig=self.kubeconfig,
+            )
+            is None
+        ):
+            logger.error("Failed to add the Traefik Helm repository.")
+            self.state = "unknown"
+            return
+        if (
+            self.exec.helm_upgrade_install(
+                conn,
+                release=self.traefik_release,
+                chart="mlflow-gateway-traefik/traefik",
+                namespace=self.namespace,
+                kubeconfig=self.kubeconfig,
+                extra_args=[
+                    "--version",
+                    self.traefik_chart_version,
+                    "--values",
+                    self.traefik_values_path,
+                    "--wait",
+                    "--timeout",
+                    "5m",
+                ],
+            )
+            is None
+        ):
+            logger.error("Failed to install the MLflow Gateway Traefik release.")
+            self.state = "unknown"
+            return
+
+        self.service_url = f"https://{conn.host}:{self.port}"
+        self.service_urls["MLflow Gateway REST API"] = self.service_url
+        self.service_ports["MLflow Gateway REST API"] = int(self.port)
+        self.state = "running"
+
+    def spin_up(self, conn) -> bool:
+        return True
+
+    def spin_down(self, conn) -> bool:
+        return True
+
+    def check(self, conn) -> dict:
+        ready = self.exec.execute(
+            conn,
+            self._kubectl(
+                f"get deployment/{self.deployment_name} "
+                f"--namespace {self.namespace} "
+                "-o jsonpath='{.status.readyReplicas}'"
+            ),
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            description="Check MLflow Gateway deployment readiness",
+        )
+        if ready is None or ready.strip() != "1":
+            self.state = "unknown"
+            return {"status": "unknown", "ready_replicas": (ready or "0").strip()}
+
+        status = self.exec.execute(
+            conn,
+            "curl --silent --show-error --insecure "
+            "--output /dev/null --write-out '%{http_code}' "
+            f"--user {shlex.quote(f'{self.user}:{self.pw}')} "
+            f"{shlex.quote(f'{self.service_url}/health')}",
+            group=TaskGroup.NETWORKING,
+            description="Check MLflow Gateway health",
+        )
+        if status is not None and status.strip() == "200":
+            self.state = "running"
+            return {"status": "running"}
+        self.state = "unknown"
+        return {"status": "unknown", "http_code": (status or "").strip()}
+
+    def teardown(self, conn) -> None:
+        self.exec.helm_uninstall(
+            conn,
+            release=self.traefik_release,
+            namespace=self.namespace,
+            kubeconfig=self.kubeconfig,
+            ignore_missing=True,
+            extra_args=[f"--timeout={self.teardown_timeout_seconds}s"],
+        )
+        self.exec.k8s_delete_resource(
+            conn,
+            "namespace",
+            self.namespace,
+            kubeconfig=self.kubeconfig,
+            ignore_not_found=True,
+            extra_args=[
+                "--wait=false",
+                f"--request-timeout={self.teardown_timeout_seconds}s",
+            ],
+        )
+        self.exec.fs_delete_dir(conn, self.target_path)
+
+        self.service_url = ""
+        self.service_urls.clear()
+        self.service_ports.clear()
+        self.state = "un-initialized"

--- a/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.k3s.yaml
+++ b/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.k3s.yaml
@@ -1,0 +1,49 @@
+id: mlflow-gateway-3.8.1-k3s
+name: MLFlow Gateway
+version: 3.8.1
+maintainer: Busy Sloths
+description_short: Lightweight multi-model HTTP gateway for MLflow on Kubernetes.
+description: Provides an authenticated HTTPS endpoint that loads MLflow pyfunc
+  models dynamically from a configured MLflow registry. The gateway and its
+  dedicated Traefik release run in an isolated Kubernetes namespace.
+links:
+  project: https://mlflow.org/
+  news: https://mlflow.org/releases/
+  security: https://mlflow.org/docs/latest/security.html
+  documentation: https://mlflow.org/docs/latest/index.html
+  changelog: https://mlflow.org/docs/latest/changelog.html
+requirements:
+  cpus: 1.0
+  ram_gb: 2.0
+  disk_gb: 2.0
+groups:
+  service: null
+  model-server: null
+  backend:
+    kubernetes: null
+capabilities:
+  service:
+  - model_server
+  backend:
+  - kubernetes
+ports:
+  rest: 30433
+build:
+  class_name: mlox.services.mlflow_gateway.k3s.MLFlowGatewayK3sService
+  params:
+    name: mlflow-gateway-3.8.1
+    template: ${MLOX_STACKS_PATH}/mlflow_gateway/mlox.mlflow_gateway.3.8.1.k3s.yaml
+    target_path: ${MLOX_USER_HOME}/mlflow-gateway-3.8.1-k3s
+    dockerfile: ${MLOX_STACKS_PATH}/mlflow_gateway/dockerfile-mlflow-gateway-3.8.1
+    serve_script: ${MLOX_STACKS_PATH}/mlflow_gateway/serve.py
+    start_script: ${MLOX_STACKS_PATH}/mlflow_gateway/start_gateway.sh
+    port: ${MLOX_AUTO_PORT_REST}
+    tracking_uri: ${TRACKING_URI}
+    tracking_user: ${TRACKING_USER}
+    tracking_pw: ${TRACKING_PW}
+    requirements_txt: ${GATEWAY_REQUIREMENTS_TXT}
+    cache_max_models: ${GATEWAY_CACHE_MAX_MODELS}
+    cache_ttl_days: ${GATEWAY_CACHE_TTL_DAYS}
+    user: ${MLOX_AUTO_USER}
+    pw: ${MLOX_AUTO_PW}
+    registry_uuid: ${MODEL_REGISTRY_UUID}

--- a/mlox/view/services/__init__.py
+++ b/mlox/view/services/__init__.py
@@ -84,7 +84,10 @@ _STREAMLIT_SERVICE_BINDINGS: dict[str, dict[str, tuple[str, ...]]] = {
         "function_names": ("settings", "setup"),
     },
     "mlox.view.services.mlflow_gateway": {
-        "config_ids": ("mlflow-gateway-3.8.1-docker",),
+        "config_ids": (
+            "mlflow-gateway-3.8.1-docker",
+            "mlflow-gateway-3.8.1-k3s",
+        ),
         "function_names": ("settings", "setup"),
     },
     "mlox.view.services.openbao": {

--- a/mlox/view/services/__init__.py
+++ b/mlox/view/services/__init__.py
@@ -55,6 +55,10 @@ _STREAMLIT_SERVICE_BINDINGS: dict[str, dict[str, tuple[str, ...]]] = {
         "config_ids": ("kubeapps-newest-k3s",),
         "function_names": ("settings",),
     },
+    "mlox.view.services.kubeflow": {
+        "config_ids": ("kubeflow-1.10.1-k3s",),
+        "function_names": ("settings",),
+    },
     "mlox.view.services.litellm": {
         "config_ids": ("litellm-ollama-1.77.7-docker",),
         "function_names": ("settings", "setup"),

--- a/mlox/view/services/kubeflow.py
+++ b/mlox/view/services/kubeflow.py
@@ -1,0 +1,25 @@
+import streamlit as st
+
+from mlox.infra import Bundle, Infrastructure
+from mlox.services.kubeflow.k8s import KubeflowService
+
+
+def settings(
+    infra: Infrastructure,  # noqa: ARG001
+    bundle: Bundle,  # noqa: ARG001
+    service: KubeflowService,
+) -> None:
+    service_url = service.service_urls.get("Kubeflow", "")
+    port = service.service_ports.get("Kubeflow", service.ingress_port)
+
+    st.link_button(
+        "Open Kubeflow",
+        url=service_url,
+        icon=":material/open_in_new:",
+    )
+    st.write(f"HTTPS port: `{port}`")
+    st.write("Initial Dex email")
+    st.code(service.dex_email)
+    st.write("Initial Dex password")
+    st.code(service.dex_password)
+    st.caption("Change the initial password after the first successful login.")

--- a/tests/unit/services/test_kubeflow_service.py
+++ b/tests/unit/services/test_kubeflow_service.py
@@ -18,6 +18,12 @@ class FakeKubernetesExec:
         self.calls = []
         self.files = {}
         self.apply_results = ["configured"]
+        self.cookie_config_result = "deployment.apps/jupyter-web-app-deployment updated"
+        self.minio_image_result = "deployment.apps/minio image updated"
+        self.helm_repo_result = "repository added"
+        self.helm_install_result = "release installed"
+        self.webhook_result = "deployment successfully rolled out"
+        self.auth_result = "deployment successfully rolled out"
         self.status = json.dumps(
             {
                 "spec": {"replicas": 1},
@@ -42,11 +48,42 @@ class FakeKubernetesExec:
         self._record("execute", command, **kwargs)
         if " get deployment centraldashboard " in f" {command} ":
             return self.status
+        if " rollout status deployment/webhook " in f" {command} ":
+            return self.webhook_result
+        if (
+            " rollout status deployment/kserve-controller-manager "
+            in f" {command} "
+        ):
+            return self.webhook_result
+        if " set image deployment/minio " in f" {command} ":
+            return self.minio_image_result
+        if " rollout " in f" {command} ":
+            return self.auth_result
+        if " set env deployment/oauth2-proxy " in f" {command} ":
+            return self.auth_result
+        if " set env deployment/jupyter-web-app-deployment " in f" {command} ":
+            return self.cookie_config_result
         return self.apply_results.pop(0)
+
+    def helm_repo_add(self, conn, *args, **kwargs):
+        self._record("helm_repo_add", *args, **kwargs)
+        return self.helm_repo_result
+
+    def helm_upgrade_install(self, conn, *args, **kwargs):
+        self._record("helm_upgrade_install", *args, **kwargs)
+        return self.helm_install_result
+
+    def helm_uninstall(self, conn, *args, **kwargs):
+        self._record("helm_uninstall", *args, **kwargs)
+        return "release uninstalled"
 
     def k8s_apply_manifest(self, conn, manifest, **kwargs):
         self._record("k8s_apply_manifest", manifest, **kwargs)
         return "ingress configured"
+
+    def k8s_patch_resource(self, conn, *args, **kwargs):
+        self._record("k8s_patch_resource", *args, **kwargs)
+        return "secret patched"
 
     def k8s_delete_resource(self, conn, *args, **kwargs):
         self._record("k8s_delete_resource", *args, **kwargs)
@@ -66,7 +103,8 @@ def test_setup_applies_upstream_manifests_and_traefik_ingress():
 
     execute_call = next(call for call in executor.calls if call[0] == "execute")
     assert execute_call[1] == (
-        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -k "
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply "
+        "--server-side --force-conflicts -k "
         "'https://github.com/kubeflow/manifests/example?ref=v1.10.1'",
     )
     assert execute_call[2] == {
@@ -74,16 +112,122 @@ def test_setup_applies_upstream_manifests_and_traefik_ingress():
         "sudo": True,
         "description": "Apply Kubeflow manifests",
     }
+    minio_image_call = next(
+        call
+        for call in executor.calls
+        if call[0] == "execute" and " set image deployment/minio " in call[1][0]
+    )
+    assert minio_image_call[1] == (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow set image deployment/minio "
+        "minio=docker.io/minio/minio:RELEASE.2019-08-14T20-37-41Z",
+    )
+    assert minio_image_call[2] == {
+        "group": TaskGroup.KUBERNETES,
+        "sudo": True,
+        "description": "Use the supported MinIO image for Kubeflow Pipelines",
+    }
+    pipeline_waits = [
+        call
+        for call in executor.calls
+        if call[0] == "execute"
+        and " -n kubeflow rollout status deployment/" in call[1][0]
+        and "--timeout=300s" in call[1][0]
+    ]
+    assert [call[1][0] for call in pipeline_waits] == [
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow rollout status deployment/mysql --timeout=300s",
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow rollout status deployment/minio --timeout=300s",
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow rollout status deployment/ml-pipeline --timeout=300s",
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow rollout status deployment/ml-pipeline-ui --timeout=300s",
+    ]
+    cookie_config_call = next(
+        call
+        for call in executor.calls
+        if call[0] == "execute"
+        and " set env deployment/jupyter-web-app-deployment " in call[1][0]
+    )
+    assert cookie_config_call[1] == (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow set env deployment/jupyter-web-app-deployment "
+        "APP_SECURE_COOKIES=true",
+    )
+    assert cookie_config_call[2] == {
+        "group": TaskGroup.KUBERNETES,
+        "sudo": True,
+        "description": "Configure secure Jupyter cookies",
+    }
+    session_key_command = next(
+        call[1][0]
+        for call in executor.calls
+        if call[0] == "execute"
+        and " set env deployment/oauth2-proxy " in call[1][0]
+    )
+    session_key_prefix = (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n oauth2-proxy set env deployment/oauth2-proxy "
+        "OAUTH2_PROXY_COOKIE_SECRET="
+    )
+    assert session_key_command.startswith(session_key_prefix)
+    assert len(session_key_command.removeprefix(session_key_prefix)) == 32
+    restart_commands = [
+        call[1][0]
+        for call in executor.calls
+        if call[0] == "execute" and " rollout restart " in call[1][0]
+    ]
+    assert restart_commands == [
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n istio-system rollout restart deployment/istiod",
+    ]
 
-    ingress_path = "/tmp/kubeflow/kubeflow-ingress.yaml"
-    ingress = executor.files[ingress_path]
-    assert "ingressClassName: traefik" in ingress
-    assert "traefik.ingress.kubernetes.io/router.entrypoints: web" in ingress
-    assert "namespace: istio-system" in ingress
-    assert "name: istio-ingressgateway" in ingress
-    assert "number: 80" in ingress
-    assert service.service_urls == {"Kubeflow": "http://cluster.example:80/"}
-    assert service.service_ports == {"Kubeflow": 80}
+    values_path = "/tmp/kubeflow/kubeflow-traefik-values.yaml"
+    values = executor.files[values_path]
+    helm_install = next(
+        call for call in executor.calls if call[0] == "helm_upgrade_install"
+    )
+    assert helm_install[2] == {
+        "release": "kubeflow-traefik",
+        "chart": "kubeflow-traefik/traefik",
+        "namespace": "kubeflow-traefik",
+        "kubeconfig": "/etc/rancher/k3s/k3s.yaml",
+        "create_namespace": True,
+        "extra_args": [
+            "--version",
+            "34.4.1",
+            "-f",
+            values_path,
+            "--wait",
+            "--timeout",
+            "5m",
+        ],
+    }
+    assert "ingressClass:\n  enabled: false" in values
+    assert "kubernetesCRD:\n    enabled: false" in values
+    assert "kubernetesIngress:\n    enabled: false" in values
+    assert "file:\n    enabled: true" in values
+    assert "rule: PathPrefix(`/`)" in values
+    assert (
+        "url: http://istio-ingressgateway.istio-system.svc.cluster.local:80"
+        in values
+    )
+    assert "port: 8443" in values
+    assert "exposedPort: 8443" in values
+    assert not any(call[0] == "k8s_apply_manifest" for call in executor.calls)
+    legacy_deletes = [
+        call for call in executor.calls if call[0] == "k8s_delete_resource"
+    ]
+    assert [call[1] for call in legacy_deletes] == [
+        ("ingress", "kubeflow"),
+        ("ingress", "kubeflow-entry"),
+        ("ingress", "kubeflow-routes"),
+        ("middleware", "kubeflow-auth-redirect"),
+        ("middleware", "kubeflow-strip-prefix"),
+    ]
+    assert service.service_urls == {"Kubeflow": "https://cluster.example:8443/"}
+    assert service.service_ports == {"Kubeflow": 8443}
     assert service.state == "running"
 
 
@@ -97,15 +241,120 @@ def test_setup_retries_manifest_apply_for_crd_discovery():
     apply_calls = [
         call
         for call in executor.calls
-        if call[0] == "execute" and " apply -k " in call[1][0]
+        if call[0] == "execute" and " apply --server-side " in call[1][0]
     ]
     assert len(apply_calls) == 3
+    knative_webhook_waits = [
+        call
+        for call in executor.calls
+        if call[0] == "execute"
+        and " rollout status deployment/webhook " in call[1][0]
+    ]
+    assert len(knative_webhook_waits) == 2
+    assert knative_webhook_waits[0][1] == (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n knative-serving rollout status deployment/webhook --timeout=120s",
+    )
+    assert knative_webhook_waits[0][2] == {
+        "group": TaskGroup.KUBERNETES,
+        "sudo": True,
+        "description": "Wait for the Knative admission webhook",
+    }
+    kserve_webhook_waits = [
+        call
+        for call in executor.calls
+        if call[0] == "execute"
+        and " rollout status deployment/kserve-controller-manager "
+        in call[1][0]
+    ]
+    assert len(kserve_webhook_waits) == 2
+    assert kserve_webhook_waits[0][1] == (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml "
+        "-n kubeflow rollout status deployment/kserve-controller-manager "
+        "--timeout=120s",
+    )
+    assert kserve_webhook_waits[0][2] == {
+        "group": TaskGroup.KUBERNETES,
+        "sudo": True,
+        "description": "Wait for the KServe admission webhook",
+    }
     assert service.state == "running"
 
 
 def test_setup_stops_when_upstream_manifests_fail():
     executor = FakeKubernetesExec()
     executor.apply_results = [None, None, None]
+    service = _service(executor)
+
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    webhook_waits = [
+        call
+        for call in executor.calls
+        if call[0] == "execute"
+        and (
+            " rollout status deployment/webhook " in call[1][0]
+            or " rollout status deployment/kserve-controller-manager "
+            in call[1][0]
+        )
+    ]
+    assert len(webhook_waits) == 4
+    assert not any(call[0] == "helm_upgrade_install" for call in executor.calls)
+    assert service.state == "unknown"
+
+
+def test_setup_stops_when_jupyter_cookie_configuration_fails():
+    executor = FakeKubernetesExec()
+    executor.cookie_config_result = None
+    service = _service(executor)
+
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    assert not any(call[0] == "helm_upgrade_install" for call in executor.calls)
+    assert service.state == "unknown"
+
+
+def test_setup_stops_when_minio_image_replacement_fails():
+    executor = FakeKubernetesExec()
+    executor.minio_image_result = None
+    service = _service(executor)
+
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    assert not any(
+        call[0] == "execute" and " rollout status deployment/mysql " in call[1][0]
+        for call in executor.calls
+    )
+    assert not any(call[0] == "helm_upgrade_install" for call in executor.calls)
+    assert service.state == "unknown"
+
+
+def test_setup_stops_when_pipeline_api_does_not_become_ready():
+    executor = FakeKubernetesExec()
+    service = _service(executor)
+    original_execute = executor.execute
+
+    def execute(conn, command, **kwargs):
+        if " rollout status deployment/ml-pipeline " in f" {command} ":
+            executor._record("execute", command, **kwargs)
+            return None
+        return original_execute(conn, command, **kwargs)
+
+    executor.execute = execute
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    assert not any(
+        call[0] == "execute"
+        and " rollout status deployment/ml-pipeline-ui " in call[1][0]
+        for call in executor.calls
+    )
+    assert not any(call[0] == "helm_upgrade_install" for call in executor.calls)
+    assert service.state == "unknown"
+
+
+def test_setup_stops_when_dedicated_traefik_install_fails():
+    executor = FakeKubernetesExec()
+    executor.helm_install_result = None
     service = _service(executor)
 
     service.setup(SimpleNamespace(host="cluster.example"))
@@ -140,29 +389,66 @@ def test_check_reports_dashboard_starting():
     }
 
 
+def test_get_secrets_returns_initial_dex_credentials():
+    executor = FakeKubernetesExec()
+    service = _service(executor)
+    service.service_urls["Kubeflow"] = "https://cluster.example:8443/"
+
+    assert service.get_secrets() == {
+        "kubeflow_dex_credentials": {
+            "email": "user@example.com",
+            "password": "12341234",
+            "service_url": "https://cluster.example:8443/",
+        }
+    }
+
+
 def test_teardown_removes_ingress_and_upstream_manifests():
     executor = FakeKubernetesExec()
     service = _service(executor)
-    service.service_urls["Kubeflow"] = "http://cluster.example:80/"
-    service.service_ports["Kubeflow"] = 80
+    service.service_urls["Kubeflow"] = "https://cluster.example:8443/"
+    service.service_ports["Kubeflow"] = 8443
 
     service.teardown(SimpleNamespace())
 
-    delete_ingress = next(
+    delete_resources = [
         call for call in executor.calls if call[0] == "k8s_delete_resource"
+    ]
+    assert [call[1] for call in delete_resources] == [
+        ("ingress", "kubeflow"),
+        ("ingress", "kubeflow-entry"),
+        ("ingress", "kubeflow-routes"),
+        ("middleware", "kubeflow-auth-redirect"),
+        ("middleware", "kubeflow-strip-prefix"),
+    ]
+    assert all(
+        call[2]
+        == {
+            "namespace": "istio-system",
+            "kubeconfig": "/etc/rancher/k3s/k3s.yaml",
+            "extra_args": ["--wait=false", "--request-timeout=120s"],
+        }
+        for call in delete_resources
     )
-    assert delete_ingress[1] == ("ingress", "kubeflow")
-    assert delete_ingress[2] == {
-        "namespace": "istio-system",
+    helm_uninstall = next(
+        call for call in executor.calls if call[0] == "helm_uninstall"
+    )
+    assert helm_uninstall[2] == {
+        "release": "kubeflow-traefik",
+        "namespace": "kubeflow-traefik",
         "kubeconfig": "/etc/rancher/k3s/k3s.yaml",
+        "extra_args": ["--timeout=120s"],
+        "ignore_missing": True,
     }
     delete_manifests = next(
         call
         for call in executor.calls
-        if call[0] == "execute" and " delete -k " in call[1][0]
+        if call[0] == "execute" and " delete --wait=false " in call[1][0]
     )
     assert delete_manifests[1] == (
-        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml delete -k "
+        "timeout --signal=TERM --kill-after=10s 120s "
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml delete "
+        "--wait=false --request-timeout=120s -k "
         "'https://github.com/kubeflow/manifests/example?ref=v1.10.1' "
         "--ignore-not-found",
     )

--- a/tests/unit/services/test_kubeflow_service.py
+++ b/tests/unit/services/test_kubeflow_service.py
@@ -1,0 +1,171 @@
+import json
+from types import SimpleNamespace
+
+from mlox.executors import TaskGroup
+from mlox.services.kubeflow.k8s import KubeflowService
+
+
+BASE = {
+    "name": "kubeflow",
+    "service_config_id": "kubeflow-1.10.1-k3s",
+    "template": "/tmp/kubeflow.yaml",
+    "target_path": "/tmp/kubeflow",
+}
+
+
+class FakeKubernetesExec:
+    def __init__(self):
+        self.calls = []
+        self.files = {}
+        self.apply_results = ["configured"]
+        self.status = json.dumps(
+            {
+                "spec": {"replicas": 1},
+                "status": {"availableReplicas": 1},
+            }
+        )
+
+    def _record(self, name, *args, **kwargs):
+        self.calls.append((name, args, kwargs))
+
+    def fs_create_dir(self, conn, path):
+        self._record("fs_create_dir", path)
+
+    def fs_write_file(self, conn, path, content):
+        self._record("fs_write_file", path, content)
+        self.files[path] = content
+
+    def fs_delete_dir(self, conn, path):
+        self._record("fs_delete_dir", path)
+
+    def execute(self, conn, command, **kwargs):
+        self._record("execute", command, **kwargs)
+        if " get deployment centraldashboard " in f" {command} ":
+            return self.status
+        return self.apply_results.pop(0)
+
+    def k8s_apply_manifest(self, conn, manifest, **kwargs):
+        self._record("k8s_apply_manifest", manifest, **kwargs)
+        return "ingress configured"
+
+    def k8s_delete_resource(self, conn, *args, **kwargs):
+        self._record("k8s_delete_resource", *args, **kwargs)
+
+
+def _service(executor):
+    service = KubeflowService(**BASE)
+    service.exec = executor
+    return service
+
+
+def test_setup_applies_upstream_manifests_and_traefik_ingress():
+    executor = FakeKubernetesExec()
+    service = _service(executor)
+
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    execute_call = next(call for call in executor.calls if call[0] == "execute")
+    assert execute_call[1] == (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml apply -k "
+        "'https://github.com/kubeflow/manifests/example?ref=v1.10.1'",
+    )
+    assert execute_call[2] == {
+        "group": TaskGroup.KUBERNETES,
+        "sudo": True,
+        "description": "Apply Kubeflow manifests",
+    }
+
+    ingress_path = "/tmp/kubeflow/kubeflow-ingress.yaml"
+    ingress = executor.files[ingress_path]
+    assert "ingressClassName: traefik" in ingress
+    assert "traefik.ingress.kubernetes.io/router.entrypoints: web" in ingress
+    assert "namespace: istio-system" in ingress
+    assert "name: istio-ingressgateway" in ingress
+    assert "number: 80" in ingress
+    assert service.service_urls == {"Kubeflow": "http://cluster.example:80/"}
+    assert service.service_ports == {"Kubeflow": 80}
+    assert service.state == "running"
+
+
+def test_setup_retries_manifest_apply_for_crd_discovery():
+    executor = FakeKubernetesExec()
+    executor.apply_results = [None, None, "configured"]
+    service = _service(executor)
+
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    apply_calls = [
+        call
+        for call in executor.calls
+        if call[0] == "execute" and " apply -k " in call[1][0]
+    ]
+    assert len(apply_calls) == 3
+    assert service.state == "running"
+
+
+def test_setup_stops_when_upstream_manifests_fail():
+    executor = FakeKubernetesExec()
+    executor.apply_results = [None, None, None]
+    service = _service(executor)
+
+    service.setup(SimpleNamespace(host="cluster.example"))
+
+    assert not any(call[0] == "k8s_apply_manifest" for call in executor.calls)
+    assert service.state == "unknown"
+
+
+def test_check_reports_dashboard_availability():
+    executor = FakeKubernetesExec()
+    service = _service(executor)
+
+    assert service.check(SimpleNamespace()) == {
+        "status": "running",
+        "details": "Kubeflow central dashboard is available.",
+    }
+
+
+def test_check_reports_dashboard_starting():
+    executor = FakeKubernetesExec()
+    executor.status = json.dumps(
+        {
+            "spec": {"replicas": 2},
+            "status": {"availableReplicas": 1},
+        }
+    )
+    service = _service(executor)
+
+    assert service.check(SimpleNamespace()) == {
+        "status": "starting",
+        "details": "Kubeflow central dashboard has 1/2 available replicas.",
+    }
+
+
+def test_teardown_removes_ingress_and_upstream_manifests():
+    executor = FakeKubernetesExec()
+    service = _service(executor)
+    service.service_urls["Kubeflow"] = "http://cluster.example:80/"
+    service.service_ports["Kubeflow"] = 80
+
+    service.teardown(SimpleNamespace())
+
+    delete_ingress = next(
+        call for call in executor.calls if call[0] == "k8s_delete_resource"
+    )
+    assert delete_ingress[1] == ("ingress", "kubeflow")
+    assert delete_ingress[2] == {
+        "namespace": "istio-system",
+        "kubeconfig": "/etc/rancher/k3s/k3s.yaml",
+    }
+    delete_manifests = next(
+        call
+        for call in executor.calls
+        if call[0] == "execute" and " delete -k " in call[1][0]
+    )
+    assert delete_manifests[1] == (
+        "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml delete -k "
+        "'https://github.com/kubeflow/manifests/example?ref=v1.10.1' "
+        "--ignore-not-found",
+    )
+    assert service.service_urls == {}
+    assert service.service_ports == {}
+    assert service.state == "un-initialized"

--- a/tests/unit/services/test_kubeflow_view.py
+++ b/tests/unit/services/test_kubeflow_view.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+from mlox.services.kubeflow.k8s import KubeflowService
+from mlox.view.services import kubeflow
+
+
+BASE = {
+    "name": "kubeflow",
+    "service_config_id": "kubeflow-1.10.1-k3s",
+    "template": "/tmp/kubeflow.yaml",
+    "target_path": "/tmp/kubeflow",
+}
+
+
+def test_settings_exposes_url_port_and_initial_credentials(monkeypatch):
+    calls = []
+    fake_streamlit = SimpleNamespace(
+        link_button=lambda *args, **kwargs: calls.append(
+            ("link_button", args, kwargs)
+        ),
+        write=lambda *args, **kwargs: calls.append(("write", args, kwargs)),
+        code=lambda *args, **kwargs: calls.append(("code", args, kwargs)),
+        caption=lambda *args, **kwargs: calls.append(("caption", args, kwargs)),
+    )
+    monkeypatch.setattr(kubeflow, "st", fake_streamlit)
+    service = KubeflowService(**BASE)
+    service.service_urls["Kubeflow"] = "https://cluster.example:8443/"
+    service.service_ports["Kubeflow"] = 8443
+
+    kubeflow.settings(None, None, service)
+
+    assert (
+        "link_button",
+        ("Open Kubeflow",),
+        {
+            "url": "https://cluster.example:8443/",
+            "icon": ":material/open_in_new:",
+        },
+    ) in calls
+    assert ("write", ("HTTPS port: `8443`",), {}) in calls
+    assert ("code", ("user@example.com",), {}) in calls
+    assert ("code", ("12341234",), {}) in calls

--- a/tests/unit/services/test_mlflow_gateway_k3s.py
+++ b/tests/unit/services/test_mlflow_gateway_k3s.py
@@ -1,0 +1,290 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from mlox.config import load_all_service_configs
+from mlox.executors import TaskGroup
+from mlox.services.mlflow_gateway.k3s import MLFlowGatewayK3sService
+from mlox.view.services import _STREAMLIT_SERVICE_BINDINGS
+
+
+class FakeExecutor:
+    def __init__(self) -> None:
+        self.files: dict[str, str] = {}
+        self.calls: list[tuple] = []
+        self.apply_result = "configured"
+        self.rollout_result = "deployment successfully rolled out"
+        self.ready_result = "1"
+        self.health_result = "200"
+        self.repo_result = "repository added"
+        self.helm_install_result = "release installed"
+
+    def _record(self, name, *args, **kwargs) -> None:
+        self.calls.append((name, args, kwargs))
+
+    def fs_create_dir(self, conn, path: str) -> None:
+        self._record("fs_create_dir", path)
+
+    def fs_write_file(self, conn, path: str, content: str) -> None:
+        self._record("fs_write_file", path, content)
+        self.files[path] = content
+
+    def fs_delete_dir(self, conn, path: str) -> None:
+        self._record("fs_delete_dir", path)
+
+    def k8s_apply_manifest(self, conn, path: str, **kwargs):
+        self._record("k8s_apply_manifest", path, **kwargs)
+        return self.apply_result
+
+    def execute(self, conn, command: str, **kwargs):
+        self._record("execute", command, **kwargs)
+        if "rollout status" in command:
+            return self.rollout_result
+        if "get deployment/" in command:
+            return self.ready_result
+        if command.startswith("curl "):
+            return self.health_result
+        raise AssertionError(f"Unexpected command: {command}")
+
+    def helm_repo_add(self, conn, *args, **kwargs):
+        self._record("helm_repo_add", *args, **kwargs)
+        return self.repo_result
+
+    def helm_upgrade_install(self, conn, **kwargs):
+        self._record("helm_upgrade_install", **kwargs)
+        return self.helm_install_result
+
+    def helm_uninstall(self, conn, **kwargs):
+        self._record("helm_uninstall", **kwargs)
+        return "release uninstalled"
+
+    def k8s_delete_resource(self, conn, *args, **kwargs):
+        self._record("k8s_delete_resource", *args, **kwargs)
+        return "namespace deleted"
+
+
+@pytest.fixture
+def gateway(tmp_path: Path) -> MLFlowGatewayK3sService:
+    serve_script = tmp_path / "serve.py"
+    serve_script.write_text(
+        "from fastapi import FastAPI\napp = FastAPI()\n", encoding="utf-8"
+    )
+    service = MLFlowGatewayK3sService(
+        name="MLflow Gateway",
+        service_config_id="mlflow-gateway-3.8.1-k3s",
+        template="/tmp/mlflow-gateway-k3s.yaml",
+        target_path="/tmp/mlflow-gateway",
+        dockerfile="/tmp/Dockerfile",
+        serve_script=str(serve_script),
+        start_script="/tmp/start_gateway.sh",
+        port=30433,
+        tracking_uri="https://mlflow.example:5043",
+        tracking_user="tracking-user",
+        tracking_pw="tracking-password",
+        requirements_txt="xgboost==2.1.0",
+        cache_max_models="5",
+        cache_ttl_days="6",
+        user="gateway-user",
+        pw="gateway-password",
+    )
+    service.exec = FakeExecutor()
+    return service
+
+
+def test_renders_gateway_manifest(gateway: MLFlowGatewayK3sService) -> None:
+    manifest = gateway._render_gateway_manifest()
+
+    assert "kind: ConfigMap" in manifest
+    assert "from fastapi import FastAPI" in manifest
+    assert "xgboost==2.1.0" in manifest
+    assert "kind: Secret" in manifest
+    assert 'gateway-user: "gateway-user"' in manifest
+    assert 'gateway-password: "gateway-password"' in manifest
+    assert 'tracking-password: "tracking-password"' in manifest
+    assert "replicas: 1" in manifest
+    assert "image: python:3.12-slim" in manifest
+    assert "startupProbe:" in manifest
+    assert manifest.count("path: /health") == 3
+    assert "name: MLOX_GATEWAY_CACHE_MAX_MODELS" in manifest
+    assert 'value: "5"' in manifest
+    assert "name: MLOX_GATEWAY_CACHE_TTL_DAYS" in manifest
+    assert 'value: "6"' in manifest
+    assert "type: ClusterIP" in manifest
+    assert "containerPort: 8080" in manifest
+    assert len(list(yaml.safe_load_all(manifest))) == 5
+
+
+def test_renders_dedicated_traefik_values(
+    gateway: MLFlowGatewayK3sService,
+) -> None:
+    values = gateway._render_traefik_values()
+
+    assert "kubernetesCRD:\n    enabled: false" in values
+    assert "kubernetesIngress:\n    enabled: false" in values
+    assert "PathPrefix(`/`)" in values
+    assert "basicAuth:" in values
+    assert "gateway-user:$apr1$" in values
+    assert "mlflow-gateway.mlflow-gateway-30433.svc.cluster.local:8080" in values
+    assert "exposedPort: 30433" in values
+    assert "type: LoadBalancer" in values
+
+
+def test_setup_applies_rolls_out_and_installs_traefik(
+    gateway: MLFlowGatewayK3sService,
+) -> None:
+    conn = SimpleNamespace(host="gateway.example")
+
+    gateway.setup(conn)
+
+    assert gateway.manifest_path in gateway.exec.files
+    assert gateway.traefik_values_path in gateway.exec.files
+    rollout = next(
+        call
+        for call in gateway.exec.calls
+        if call[0] == "execute" and "rollout status" in call[1][0]
+    )
+    assert rollout[2]["group"] == TaskGroup.KUBERNETES
+    install = next(
+        call for call in gateway.exec.calls if call[0] == "helm_upgrade_install"
+    )
+    assert install[2]["extra_args"] == [
+        "--version",
+        "34.4.1",
+        "--values",
+        gateway.traefik_values_path,
+        "--wait",
+        "--timeout",
+        "5m",
+    ]
+    assert gateway.service_url == "https://gateway.example:30433"
+    assert gateway.service_ports == {"MLflow Gateway REST API": 30433}
+    assert gateway.state == "running"
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_helm_installs"),
+    [
+        ("apply", 0),
+        ("rollout", 0),
+        ("traefik", 1),
+    ],
+)
+def test_setup_failure_paths(
+    gateway: MLFlowGatewayK3sService,
+    failure: str,
+    expected_helm_installs: int,
+) -> None:
+    if failure == "apply":
+        gateway.exec.apply_result = None
+    elif failure == "rollout":
+        gateway.exec.rollout_result = None
+    else:
+        gateway.exec.helm_install_result = None
+
+    gateway.setup(SimpleNamespace(host="gateway.example"))
+
+    assert gateway.state == "unknown"
+    installs = [
+        call for call in gateway.exec.calls if call[0] == "helm_upgrade_install"
+    ]
+    assert len(installs) == expected_helm_installs
+
+
+def test_check_uses_deployment_and_authenticated_health(
+    gateway: MLFlowGatewayK3sService,
+) -> None:
+    conn = SimpleNamespace(host="gateway.example")
+    gateway.service_url = "https://gateway.example:30433"
+
+    assert gateway.check(conn) == {"status": "running"}
+    curl = next(
+        call[1][0]
+        for call in gateway.exec.calls
+        if call[0] == "execute" and call[1][0].startswith("curl ")
+    )
+    assert "--insecure" in curl
+    assert "--user gateway-user:gateway-password" in curl
+    assert curl.endswith("https://gateway.example:30433/health")
+
+    gateway.exec.ready_result = ""
+    assert gateway.check(conn)["status"] == "unknown"
+
+
+def test_teardown_is_non_blocking_and_clears_service_state(
+    gateway: MLFlowGatewayK3sService,
+) -> None:
+    gateway.service_url = "https://gateway.example:30433"
+    gateway.service_urls["MLflow Gateway REST API"] = gateway.service_url
+    gateway.service_ports["MLflow Gateway REST API"] = 30433
+    gateway.state = "running"
+
+    gateway.teardown(SimpleNamespace(host="gateway.example"))
+
+    uninstall = next(call for call in gateway.exec.calls if call[0] == "helm_uninstall")
+    delete = next(
+        call for call in gateway.exec.calls if call[0] == "k8s_delete_resource"
+    )
+    assert uninstall[2]["extra_args"] == ["--timeout=120s"]
+    assert delete[2]["extra_args"] == [
+        "--wait=false",
+        "--request-timeout=120s",
+    ]
+    assert any(call[0] == "fs_delete_dir" for call in gateway.exec.calls)
+    assert gateway.service_url == ""
+    assert gateway.service_urls == {}
+    assert gateway.state == "un-initialized"
+
+
+def test_reuses_gateway_secrets_and_model_validation(
+    gateway: MLFlowGatewayK3sService,
+) -> None:
+    assert gateway.get_secrets() == {
+        "mlflow_gateway_basic_auth": {
+            "username": "gateway-user",
+            "password": "gateway-password",
+            "service_url": "",
+        },
+        "mlflow_tracking_credentials": {
+            "username": "tracking-user",
+            "password": "tracking-password",
+            "tracking_uri": "https://mlflow.example:5043",
+            "cache_max_models": "5",
+            "cache_ttl_days": "6",
+        },
+    }
+    assert not gateway.is_model("registered-model")
+
+
+def test_catalog_and_streamlit_handlers_are_registered() -> None:
+    configs = {config.id: config for config in load_all_service_configs()}
+    config = configs["mlflow-gateway-3.8.1-k3s"]
+
+    assert config.capabilities["backend"] == ["kubernetes"]
+    assert config.capabilities["service"] == ["model_server"]
+    assert (
+        config.build.class_name
+        == "mlox.services.mlflow_gateway.k3s.MLFlowGatewayK3sService"
+    )
+    service = config.instantiate_service(
+        {
+            "${MLOX_STACKS_PATH}": str(Path(__file__).parents[3] / "mlox" / "services"),
+            "${MLOX_USER_HOME}": "/tmp/mlox",
+            "${MLOX_AUTO_PORT_REST}": 30433,
+            "${TRACKING_URI}": "https://mlflow.example",
+            "${TRACKING_USER}": "tracking-user",
+            "${TRACKING_PW}": "tracking-password",
+            "${GATEWAY_REQUIREMENTS_TXT}": "",
+            "${GATEWAY_CACHE_MAX_MODELS}": "10",
+            "${GATEWAY_CACHE_TTL_DAYS}": "10",
+            "${MLOX_AUTO_USER}": "gateway-user",
+            "${MLOX_AUTO_PW}": "gateway-password",
+            "${MODEL_REGISTRY_UUID}": "",
+        }
+    )
+    assert isinstance(service, MLFlowGatewayK3sService)
+    assert service.namespace == "mlflow-gateway-30433"
+    binding = _STREAMLIT_SERVICE_BINDINGS["mlox.view.services.mlflow_gateway"]
+    assert "mlflow-gateway-3.8.1-k3s" in binding["config_ids"]
+    assert binding["function_names"] == ("settings", "setup")


### PR DESCRIPTION
### Motivation
- Provide a first-class MLOX service to install and manage Kubeflow on Kubernetes clusters (targeting k3s environments).  
- Expose Kubeflow's Istio ingress gateway through the default Traefik ingress controller used by k3s to make the central dashboard reachable.  
- Handle manifest/CRD propagation issues by retrying idempotent apply operations to improve reliability of automated installs.

### Description
- Add `mlox.services.kubeflow.k8s.KubeflowService` which applies upstream Kubeflow manifests via `kubectl -k` and exposes an ingress for Traefik; health checks query the `centraldashboard` deployment.  
- Implement install retry logic in `_apply_kubeflow_manifests` to work around CRD discovery delays and add `_run_kustomize` and `_kubectl_command` helpers that invoke the executor.  
- Generate a Traefik-compatible Ingress manifest in `_write_ingress_manifest` that routes the `web` entrypoint to the `istio-ingressgateway` service and register the service URL/port in `service_urls`/`service_ports`.  
- Register the service in the catalog with `mlox.services.kubeflow/mlox.kubeflow.yaml` and add unit tests at `tests/unit/services/test_kubeflow_service.py` covering setup, retry behavior, failure handling, ingress generation, health checks, and teardown.

### Testing
- Ran the new unit tests `pytest tests/unit/services/test_kubeflow_service.py` which passed (`6 passed`).  
- Executed the full unit test suite `pytest tests/unit` which passed (`338 passed`) to ensure no regressions.  
- Performed static/compile checks using `ruff check` and `python -m compileall` on the new module which completed without errors.  
- Verified the service config can be loaded and instantiated via `load_all_service_configs()` as a smoke check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e80c0948c8322b3971b590f4d9347)