### PR TITLE
Add Developers Terminal Dream service

### DIFF
--- a/mlox/config.py
+++ b/mlox/config.py
@@ -72,6 +72,8 @@ SERVICE_GROUP_ALIASES = {
     "deployment": ServiceCapability.DEPLOYMENT.value,
     "llm": ServiceCapability.LLM.value,
     "dashboard": ServiceCapability.DASHBOARD.value,
+    "developer_tools": ServiceCapability.DEVELOPER_TOOLS.value,
+    "developer-tools": ServiceCapability.DEVELOPER_TOOLS.value,
 }
 
 

--- a/mlox/service.py
+++ b/mlox/service.py
@@ -58,6 +58,7 @@ class ServiceCapability(StrEnum):
     DEPLOYMENT = "deployment"
     LLM = "llm"
     DASHBOARD = "dashboard"
+    DEVELOPER_TOOLS = "developer_tools"
 
 
 class AbstractSecretManagerService(ABC):

--- a/mlox/services/dev_terminal/__init__.py
+++ b/mlox/services/dev_terminal/__init__.py
@@ -1,0 +1,1 @@
+"""Developer terminal service package."""

--- a/mlox/services/dev_terminal/mlox.dev_terminal.yaml
+++ b/mlox/services/dev_terminal/mlox.dev_terminal.yaml
@@ -26,6 +26,8 @@ groups:
     native: null
     docker: null
     kubernetes: null
+    kubernetes-agent: null
+    k3s-agent: null
 capabilities:
   service:
   - developer_tools
@@ -33,6 +35,8 @@ capabilities:
   - native
   - docker
   - kubernetes
+  - kubernetes_agent
+  - k3s_agent
 build:
   class_name: mlox.services.dev_terminal.service.DeveloperTerminalService
   params:

--- a/mlox/services/dev_terminal/mlox.dev_terminal.yaml
+++ b/mlox/services/dev_terminal/mlox.dev_terminal.yaml
@@ -1,0 +1,40 @@
+id: dev-terminal-0.1-beta
+name: Developers Terminal Dream
+version: 0.1-beta
+maintainer: Busy Sloths
+description_short: Install a terminal-first developer workstation on MLOX backends.
+description: 'Developers Terminal Dream turns a remote backend into a comfortable
+  terminal developer machine. It installs and configures LazyVim, zsh, Atuin shell
+  history, Midnight Commander, Yazi, Claude Code, Spaceship prompt, OpenSSH, git,
+  and practical terminal utilities. Although it is implemented as a native host
+  bootstrapper, it also fits Docker and Kubernetes-capable Ubuntu backends because
+  those backends expose the same remote host where developers run shells and tools.
+
+  '
+links:
+  project: https://mlox.org
+  documentation: https://github.com/busysloths/mlox/
+requirements:
+  cpus: 1.0
+  ram_gb: 1.0
+  disk_gb: 2.0
+groups:
+  service: null
+  developer-tools: null
+  backend:
+    native: null
+    docker: null
+    kubernetes: null
+capabilities:
+  service:
+  - developer_tools
+  backend:
+  - native
+  - docker
+  - kubernetes
+build:
+  class_name: mlox.services.dev_terminal.service.DeveloperTerminalService
+  params:
+    name: dev-terminal:${MLOX_SERVER_IP}
+    template: ${MLOX_STACKS_PATH}/dev_terminal/mlox.dev_terminal.yaml
+    target_path: ${MLOX_USER_HOME}/.mlox/dev-terminal

--- a/mlox/services/dev_terminal/mlox.dev_terminal.yaml
+++ b/mlox/services/dev_terminal/mlox.dev_terminal.yaml
@@ -5,8 +5,9 @@ maintainer: Busy Sloths
 description_short: Install a terminal-first developer workstation on MLOX backends.
 description: 'Developers Terminal Dream turns a remote backend into a comfortable
   terminal developer machine. It installs and configures LazyVim, zsh, Atuin shell
-  history, Midnight Commander, Yazi, Claude Code, Spaceship prompt, OpenSSH, git,
-  and practical terminal utilities. Although it is implemented as a native host
+  history, Midnight Commander, Yazi, Claude Code, Spaceship prompt, git, pyenv,
+  and practical terminal utilities. OpenSSH is expected to come from the MLOX
+  server bootstrap. Although it is implemented as a native host
   bootstrapper, it also fits Docker and Kubernetes-capable Ubuntu backends because
   those backends expose the same remote host where developers run shells and tools.
 

--- a/mlox/services/dev_terminal/mlox.dev_terminal.yaml
+++ b/mlox/services/dev_terminal/mlox.dev_terminal.yaml
@@ -5,7 +5,7 @@ maintainer: Busy Sloths
 description_short: Install a terminal-first developer workstation on MLOX backends.
 description: 'Developers Terminal Dream turns a remote backend into a comfortable
   terminal developer machine. It installs and configures LazyVim, zsh, Atuin shell
-  history, Midnight Commander, Yazi, Claude Code, Spaceship prompt, git, pyenv,
+  history, Midnight Commander, Yazi, LazyVim integrations for Yazi and Claude Code, Spaceship prompt, git, pyenv,
   and practical terminal utilities. OpenSSH is expected to come from the MLOX
   server bootstrap. Although it is implemented as a native host
   bootstrapper, it also fits Docker and Kubernetes-capable Ubuntu backends because

--- a/mlox/services/dev_terminal/service.py
+++ b/mlox/services/dev_terminal/service.py
@@ -42,6 +42,7 @@ INSTALL_LAZYVIM={lazyvim}
 INSTALL_YAZI={yazi}
 INSTALL_SPACESHIP={spaceship}
 INSTALL_PYENV={pyenv}
+MIN_NVIM_VERSION=0.11.2
 TARGET_USER="${{SUDO_USER:-$(id -un)}}"
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
@@ -53,12 +54,41 @@ apt-get install -yq \
   bash bat btop build-essential ca-certificates curl direnv fd-find fzf git \
   gnupg gzip htop jq libbz2-dev libffi-dev liblzma-dev libncursesw5-dev \
   libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxmlsec1-dev \
-  llvm lsb-release make mc neovim nodejs npm pipx python3 python3-pip \
-  ripgrep tar tk-dev tmux unzip wget xz-utils zlib1g-dev zsh
+  llvm locales lsb-release make mc nodejs npm pipx python3 python3-pip \
+  ripgrep snapd tar tk-dev tmux unzip wget xz-utils zlib1g-dev zsh
+
+locale-gen C.UTF-8 >/dev/null 2>&1 || true
+update-locale LANG=C.UTF-8 LC_CTYPE=C.UTF-8 >/dev/null 2>&1 || true
 
 # Ubuntu/Debian package names the fd and bat binaries differently.
 ln -sf /usr/bin/fdfind /usr/local/bin/fd 2>/dev/null || true
 ln -sf /usr/bin/batcat /usr/local/bin/bat 2>/dev/null || true
+
+nvim_version() {{
+  if command -v nvim >/dev/null 2>&1; then
+    nvim --version | sed -n '1s/^NVIM v//p' | cut -d- -f1
+  fi
+}}
+
+nvim_version_meets_min() {{
+  local version
+  version="$(nvim_version)"
+  [ -n "$version" ] && dpkg --compare-versions "$version" ge "$MIN_NVIM_VERSION"
+}}
+
+if ! nvim_version_meets_min; then
+  systemctl enable --now snapd.socket >/dev/null 2>&1 || true
+  snap wait system seed.loaded >/dev/null 2>&1 || true
+  snap install nvim --classic
+  if [ -x /snap/bin/nvim ]; then
+    ln -sf /snap/bin/nvim /usr/local/bin/nvim
+  fi
+fi
+
+if ! nvim_version_meets_min; then
+  echo "Neovim $MIN_NVIM_VERSION or newer is required for LazyVim." >&2
+  exit 1
+fi
 
 npm install -g neovim tree-sitter-cli || true
 if [ "$INSTALL_CLAUDE_CODE" = true ]; then
@@ -68,8 +98,9 @@ if [ "$INSTALL_SPACESHIP" = true ]; then
   npm install -g spaceship-prompt || true
 fi
 
-if [ "$INSTALL_ATUIN" = true ] && ! command -v atuin >/dev/null 2>&1; then
-  curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh || true
+if [ "$INSTALL_ATUIN" = true ] && ! command -v atuin >/dev/null 2>&1 && [ ! -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
+  sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" sh -c \
+    "curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh" || true
   if [ -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
     ln -sf "$TARGET_HOME/.atuin/bin/atuin" /usr/local/bin/atuin
   fi
@@ -95,10 +126,22 @@ if [ "$INSTALL_YAZI" = true ] && ! command -v yazi >/dev/null 2>&1; then
 fi
 
 
-if [ "$INSTALL_PYENV" = true ] && ! command -v pyenv >/dev/null 2>&1; then
-  if [ ! -d "$TARGET_HOME/.pyenv" ]; then
-    sudo -u "$TARGET_USER" git clone https://github.com/pyenv/pyenv.git "$TARGET_HOME/.pyenv" || true
+if [ "$INSTALL_PYENV" = true ]; then
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.pyenv"
+  if [ ! -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
+    if [ -d "$TARGET_HOME/.pyenv/.git" ]; then
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" pull --ff-only || true
+    elif [ -z "$(find "$TARGET_HOME/.pyenv" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git clone https://github.com/pyenv/pyenv.git "$TARGET_HOME/.pyenv" || true
+    else
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" init || true
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" remote add origin https://github.com/pyenv/pyenv.git 2>/dev/null || \
+        sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" remote set-url origin https://github.com/pyenv/pyenv.git || true
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" fetch --depth 1 origin master || true
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" checkout -f FETCH_HEAD || true
+    fi
   fi
+  chown -R "$TARGET_USER:$TARGET_USER" "$TARGET_HOME/.pyenv" || true
   if [ -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
     ln -sf "$TARGET_HOME/.pyenv/bin/pyenv" /usr/local/bin/pyenv
   fi
@@ -166,18 +209,34 @@ append_once() {{
   local line="$1"
   grep -qxF "$line" "$ZSHRC" 2>/dev/null || echo "$line" >> "$ZSHRC"
 }}
+remove_line() {{
+  local line="$1"
+  if [ -f "$ZSHRC" ]; then
+    grep -vxF "$line" "$ZSHRC" > "$ZSHRC.tmp" 2>/dev/null || true
+    cat "$ZSHRC.tmp" > "$ZSHRC"
+    rm -f "$ZSHRC.tmp"
+  fi
+}}
+remove_line '[ -x "$HOME/.atuin/bin/atuin" ] && eval "$($HOME/.atuin/bin/atuin init zsh)"'
+remove_line 'command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"'
+remove_line '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+remove_line 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init - zsh)"'
 append_once 'export EDITOR=nvim'
 append_once 'export VISUAL=nvim'
+append_once 'export LANG=C.UTF-8'
+append_once 'export LC_CTYPE=C.UTF-8'
+append_once 'unset LC_ALL'
 append_once 'export PYENV_ROOT="$HOME/.pyenv"'
-append_once '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-append_once 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init - zsh)"'
+append_once '[[ -d "$PYENV_ROOT/bin" ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+append_once '[[ -d "$PYENV_ROOT/shims" ]] && export PATH="$PYENV_ROOT/shims:$PATH"'
+append_once '[[ -d "$HOME/.atuin/bin" ]] && export PATH="$HOME/.atuin/bin:$PATH"'
+append_once 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init -)"'
 append_once 'alias ll="ls -lah"'
 append_once 'alias vim="nvim"'
 append_once 'alias vi="nvim"'
 append_once 'alias fm="yazi"'
 append_once 'eval "$(direnv hook zsh)"'
-append_once '[ -x "$HOME/.atuin/bin/atuin" ] && eval "$($HOME/.atuin/bin/atuin init zsh)"'
-append_once 'command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"'
+append_once 'if [ -x "$HOME/.atuin/bin/atuin" ]; then eval "$($HOME/.atuin/bin/atuin init zsh)"; elif command -v atuin >/dev/null 2>&1; then eval "$(atuin init zsh)"; fi'
 append_once '[ -f "$(npm root -g 2>/dev/null)/spaceship-prompt/spaceship.zsh" ] && source "$(npm root -g)/spaceship-prompt/spaceship.zsh"'
 chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
 
@@ -212,7 +271,9 @@ fi
         return True
 
     def check(self, conn) -> Dict[str, str]:
-        command = "command -v zsh git nvim mc yazi atuin claude pyenv >/dev/null"
+        command = """command -v zsh git nvim mc yazi atuin claude pyenv >/dev/null
+nvim_version="$(nvim --version | sed -n '1s/^NVIM v//p' | cut -d- -f1)"
+[ -n "$nvim_version" ] && dpkg --compare-versions "$nvim_version" ge 0.11.2"""
         try:
             self.exec.execute(conn, command, group=TaskGroup.AD_HOC)
             self.state = "running"

--- a/mlox/services/dev_terminal/service.py
+++ b/mlox/services/dev_terminal/service.py
@@ -23,6 +23,7 @@ class DeveloperTerminalService(AbstractService):
     install_lazyvim: bool = True
     install_yazi: bool = True
     install_spaceship: bool = True
+    install_pyenv: bool = True
     installed_tools: list[str] = field(default_factory=list, init=False)
 
     def _install_script(self) -> str:
@@ -31,6 +32,7 @@ class DeveloperTerminalService(AbstractService):
         lazyvim = "true" if self.install_lazyvim else "false"
         yazi = "true" if self.install_yazi else "false"
         spaceship = "true" if self.install_spaceship else "false"
+        pyenv = "true" if self.install_pyenv else "false"
         return f"""#!/usr/bin/env bash
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
@@ -39,6 +41,7 @@ INSTALL_ATUIN={atuin}
 INSTALL_LAZYVIM={lazyvim}
 INSTALL_YAZI={yazi}
 INSTALL_SPACESHIP={spaceship}
+INSTALL_PYENV={pyenv}
 TARGET_USER="${{SUDO_USER:-$(id -un)}}"
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
@@ -48,17 +51,14 @@ fi
 apt-get update
 apt-get install -yq \
   bash bat btop build-essential ca-certificates curl direnv fd-find fzf git \
-  gnupg gzip htop jq lsb-release mc neovim nodejs npm openssh-client \
-  openssh-server pipx python3 python3-pip ripgrep tar tmux unzip wget xz-utils zsh
+  gnupg gzip htop jq libbz2-dev libffi-dev liblzma-dev libncursesw5-dev \
+  libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxmlsec1-dev \
+  llvm lsb-release make mc neovim nodejs npm pipx python3 python3-pip \
+  ripgrep tar tk-dev tmux unzip wget xz-utils zlib1g-dev zsh
 
 # Ubuntu/Debian package names the fd and bat binaries differently.
 ln -sf /usr/bin/fdfind /usr/local/bin/fd 2>/dev/null || true
 ln -sf /usr/bin/batcat /usr/local/bin/bat 2>/dev/null || true
-
-if command -v systemctl >/dev/null 2>&1; then
-  systemctl enable ssh || systemctl enable sshd || true
-  systemctl start ssh || systemctl start sshd || true
-fi
 
 npm install -g neovim tree-sitter-cli || true
 if [ "$INSTALL_CLAUDE_CODE" = true ]; then
@@ -94,6 +94,16 @@ if [ "$INSTALL_YAZI" = true ] && ! command -v yazi >/dev/null 2>&1; then
   rm -rf "$tmpdir"
 fi
 
+
+if [ "$INSTALL_PYENV" = true ] && ! command -v pyenv >/dev/null 2>&1; then
+  if [ ! -d "$TARGET_HOME/.pyenv" ]; then
+    sudo -u "$TARGET_USER" git clone https://github.com/pyenv/pyenv.git "$TARGET_HOME/.pyenv" || true
+  fi
+  if [ -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
+    ln -sf "$TARGET_HOME/.pyenv/bin/pyenv" /usr/local/bin/pyenv
+  fi
+fi
+
 if [ "$INSTALL_LAZYVIM" = true ]; then
   install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config"
   if [ ! -d "$TARGET_HOME/.config/nvim" ]; then
@@ -111,6 +121,9 @@ append_once() {{
 }}
 append_once 'export EDITOR=nvim'
 append_once 'export VISUAL=nvim'
+append_once 'export PYENV_ROOT="$HOME/.pyenv"'
+append_once '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+append_once 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init - zsh)"'
 append_once 'alias ll="ls -lah"'
 append_once 'alias vim="nvim"'
 append_once 'alias vi="nvim"'
@@ -152,7 +165,7 @@ fi
         return True
 
     def check(self, conn) -> Dict[str, str]:
-        command = "command -v zsh git ssh nvim mc yazi atuin claude >/dev/null"
+        command = "command -v zsh git nvim mc yazi atuin claude pyenv >/dev/null"
         try:
             self.exec.execute(conn, command, group=TaskGroup.AD_HOC)
             self.state = "running"

--- a/mlox/services/dev_terminal/service.py
+++ b/mlox/services/dev_terminal/service.py
@@ -1,0 +1,166 @@
+"""Native developer terminal workstation bootstrap service."""
+
+from __future__ import annotations
+
+import logging
+import shlex
+from dataclasses import dataclass, field
+from typing import Dict
+
+from mlox.execution import TaskGroup
+from mlox.service import AbstractService, ServiceCapability
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DeveloperTerminalService(AbstractService):
+    """Install an opinionated terminal developer environment on a backend host."""
+
+    capabilities = {ServiceCapability.DEVELOPER_TOOLS}
+    install_claude_code: bool = True
+    install_atuin: bool = True
+    install_lazyvim: bool = True
+    install_yazi: bool = True
+    install_spaceship: bool = True
+    installed_tools: list[str] = field(default_factory=list, init=False)
+
+    def _install_script(self) -> str:
+        claude = "true" if self.install_claude_code else "false"
+        atuin = "true" if self.install_atuin else "false"
+        lazyvim = "true" if self.install_lazyvim else "false"
+        yazi = "true" if self.install_yazi else "false"
+        spaceship = "true" if self.install_spaceship else "false"
+        return f"""#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+INSTALL_CLAUDE_CODE={claude}
+INSTALL_ATUIN={atuin}
+INSTALL_LAZYVIM={lazyvim}
+INSTALL_YAZI={yazi}
+INSTALL_SPACESHIP={spaceship}
+TARGET_USER="${{SUDO_USER:-$(id -un)}}"
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
+  TARGET_HOME="$HOME"
+fi
+
+apt-get update
+apt-get install -yq \
+  bash bat btop build-essential ca-certificates curl direnv fd-find fzf git \
+  gnupg gzip htop jq lsb-release mc neovim nodejs npm openssh-client \
+  openssh-server pipx python3 python3-pip ripgrep tar tmux unzip wget xz-utils zsh
+
+# Ubuntu/Debian package names the fd and bat binaries differently.
+ln -sf /usr/bin/fdfind /usr/local/bin/fd 2>/dev/null || true
+ln -sf /usr/bin/batcat /usr/local/bin/bat 2>/dev/null || true
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl enable ssh || systemctl enable sshd || true
+  systemctl start ssh || systemctl start sshd || true
+fi
+
+npm install -g neovim tree-sitter-cli || true
+if [ "$INSTALL_CLAUDE_CODE" = true ]; then
+  npm install -g @anthropic-ai/claude-code || true
+fi
+if [ "$INSTALL_SPACESHIP" = true ]; then
+  npm install -g spaceship-prompt || true
+fi
+
+if [ "$INSTALL_ATUIN" = true ] && ! command -v atuin >/dev/null 2>&1; then
+  curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh || true
+  if [ -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
+    ln -sf "$TARGET_HOME/.atuin/bin/atuin" /usr/local/bin/atuin
+  fi
+fi
+
+if [ "$INSTALL_YAZI" = true ] && ! command -v yazi >/dev/null 2>&1; then
+  tmpdir="$(mktemp -d)"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) yazi_arch="x86_64-unknown-linux-gnu" ;;
+    aarch64|arm64) yazi_arch="aarch64-unknown-linux-gnu" ;;
+    *) yazi_arch="" ;;
+  esac
+  if [ -n "$yazi_arch" ]; then
+    curl -fsSL "https://github.com/sxyazi/yazi/releases/latest/download/yazi-${{yazi_arch}}.zip" -o "$tmpdir/yazi.zip" || true
+    if [ -s "$tmpdir/yazi.zip" ]; then
+      unzip -q "$tmpdir/yazi.zip" -d "$tmpdir"
+      find "$tmpdir" -type f -name yazi -exec install -m 0755 {{}} /usr/local/bin/yazi \\; -quit
+      find "$tmpdir" -type f -name ya -exec install -m 0755 {{}} /usr/local/bin/ya \\; -quit
+    fi
+  fi
+  rm -rf "$tmpdir"
+fi
+
+if [ "$INSTALL_LAZYVIM" = true ]; then
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config"
+  if [ ! -d "$TARGET_HOME/.config/nvim" ]; then
+    sudo -u "$TARGET_USER" git clone https://github.com/LazyVim/starter "$TARGET_HOME/.config/nvim" || true
+    rm -rf "$TARGET_HOME/.config/nvim/.git"
+  fi
+fi
+
+ZSHRC="$TARGET_HOME/.zshrc"
+touch "$ZSHRC"
+chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
+append_once() {{
+  local line="$1"
+  grep -qxF "$line" "$ZSHRC" 2>/dev/null || echo "$line" >> "$ZSHRC"
+}}
+append_once 'export EDITOR=nvim'
+append_once 'export VISUAL=nvim'
+append_once 'alias ll="ls -lah"'
+append_once 'alias vim="nvim"'
+append_once 'alias vi="nvim"'
+append_once 'alias fm="yazi"'
+append_once 'eval "$(direnv hook zsh)"'
+append_once '[ -x "$HOME/.atuin/bin/atuin" ] && eval "$($HOME/.atuin/bin/atuin init zsh)"'
+append_once 'command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"'
+append_once '[ -f "$(npm root -g 2>/dev/null)/spaceship-prompt/spaceship.zsh" ] && source "$(npm root -g)/spaceship-prompt/spaceship.zsh"'
+chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
+
+if command -v zsh >/dev/null 2>&1; then
+  chsh -s "$(command -v zsh)" "$TARGET_USER" || true
+fi
+"""
+
+    def setup(self, conn) -> None:
+        self.exec.fs_create_dir(conn, self.target_path)
+        script_path = f"{self.target_path}/install-developer-terminal.sh"
+        self.exec.fs_write_file(conn, script_path, self._install_script())
+        quoted_script_path = shlex.quote(script_path)
+        self.exec.execute(
+            conn, f"chmod +x {quoted_script_path}", group=TaskGroup.FILESYSTEM
+        )
+        self.exec.execute(
+            conn, quoted_script_path, group=TaskGroup.SYSTEM_PACKAGES, sudo=True
+        )
+        self.state = "running"
+
+    def teardown(self, conn) -> None:
+        self.exec.fs_delete_dir(conn, self.target_path)
+        self.state = "un-initialized"
+
+    def spin_up(self, conn) -> bool:
+        self.state = "running"
+        return True
+
+    def spin_down(self, conn) -> bool:
+        self.state = "stopped"
+        return True
+
+    def check(self, conn) -> Dict[str, str]:
+        command = "command -v zsh git ssh nvim mc yazi atuin claude >/dev/null"
+        try:
+            self.exec.execute(conn, command, group=TaskGroup.AD_HOC)
+            self.state = "running"
+            return {"status": "running"}
+        except Exception as exc:
+            logger.warning("Developer terminal check failed: %s", exc)
+            self.state = "unknown"
+            return {"status": "unknown"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}

--- a/mlox/services/dev_terminal/service.py
+++ b/mlox/services/dev_terminal/service.py
@@ -110,6 +110,53 @@ if [ "$INSTALL_LAZYVIM" = true ]; then
     sudo -u "$TARGET_USER" git clone https://github.com/LazyVim/starter "$TARGET_HOME/.config/nvim" || true
     rm -rf "$TARGET_HOME/.config/nvim/.git"
   fi
+
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config/nvim/lua/plugins"
+  NVIM_PLUGIN="$TARGET_HOME/.config/nvim/lua/plugins/mlox-dev-terminal.lua"
+  cat > "$NVIM_PLUGIN" <<'MLOX_LAZYVIM_DEV_TERMINAL'
+-- MLOX Developers Terminal Dream: Claude Code and Yazi integrations for LazyVim.
+return {{
+  {{
+    "coder/claudecode.nvim",
+    opts = {{}},
+    keys = {{
+      {{ "<leader>a", "", desc = "+ai", mode = {{ "n", "v" }} }},
+      {{ "<leader>ac", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude" }},
+      {{ "<leader>af", "<cmd>ClaudeCodeFocus<cr>", desc = "Focus Claude" }},
+      {{ "<leader>ar", "<cmd>ClaudeCode --resume<cr>", desc = "Resume Claude" }},
+      {{ "<leader>aC", "<cmd>ClaudeCode --continue<cr>", desc = "Continue Claude" }},
+      {{ "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>", desc = "Add current buffer" }},
+      {{ "<leader>as", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" }},
+      {{ "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" }},
+      {{ "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" }},
+    }},
+  }},
+  {{
+    "mikavilpas/yazi.nvim",
+    version = "*",
+    event = "VeryLazy",
+    dependencies = {{
+      {{ "nvim-lua/plenary.nvim", lazy = true }},
+    }},
+    keys = {{
+      {{ "<leader>-", "<cmd>Yazi<cr>", mode = {{ "n", "v" }}, desc = "Open yazi at the current file" }},
+      {{ "<leader>cw", "<cmd>Yazi cwd<cr>", desc = "Open yazi in nvim cwd" }},
+      {{ "<c-up>", "<cmd>Yazi toggle<cr>", desc = "Resume yazi" }},
+    }},
+    opts = {{
+      open_for_directories = true,
+      open_multiple_tabs = true,
+      keymaps = {{
+        show_help = "<f1>",
+      }},
+    }},
+    init = function()
+      vim.g.loaded_netrwPlugin = 1
+    end,
+  }},
+}}
+MLOX_LAZYVIM_DEV_TERMINAL
+  chown "$TARGET_USER:$TARGET_USER" "$NVIM_PLUGIN" || true
 fi
 
 ZSHRC="$TARGET_HOME/.zshrc"

--- a/mlox/tui/screens/dashboard/model.py
+++ b/mlox/tui/screens/dashboard/model.py
@@ -42,7 +42,7 @@ def get_server_backends(server: Any | None) -> list[str]:
     if isinstance(raw_backends, str):
         raw_backends = [raw_backends]
     return [
-        str(backend).strip().lower()
+        str(backend).strip().lower().replace("-", "_")
         for backend in raw_backends or []
         if str(backend).strip()
     ]

--- a/tests/unit/services/test_dev_terminal_service.py
+++ b/tests/unit/services/test_dev_terminal_service.py
@@ -1,0 +1,80 @@
+from mlox.services.dev_terminal.service import DeveloperTerminalService
+
+
+def _service() -> DeveloperTerminalService:
+    return DeveloperTerminalService(
+        name="dev-terminal:test",
+        service_config_id="dev-terminal-0.1-beta",
+        template="template.yaml",
+        target_path="/tmp/dev-terminal",
+    )
+
+
+def test_install_script_installs_modern_neovim_with_snap_when_needed() -> None:
+    script = _service()._install_script()
+
+    assert "MIN_NVIM_VERSION=0.11.2" in script
+    assert "nvim_version_meets_min" in script
+    assert "snapd" in script
+    assert "snap install nvim --classic" in script
+    assert "ln -sf /snap/bin/nvim /usr/local/bin/nvim" in script
+    assert "Neovim $MIN_NVIM_VERSION or newer is required for LazyVim." in script
+    assert " mc neovim nodejs " not in script
+
+
+def test_check_requires_lazyvim_compatible_neovim() -> None:
+    service = _service()
+    commands: list[str] = []
+
+    class Exec:
+        def execute(self, _conn, command, **_kwargs):
+            commands.append(command)
+
+    service.exec = Exec()  # type: ignore[assignment]
+
+    assert service.check(object()) == {"status": "running"}
+    assert commands
+    assert "nvim --version" in commands[0]
+    assert 'dpkg --compare-versions "$nvim_version" ge 0.11.2' in commands[0]
+
+
+def test_install_script_installs_atuin_for_target_user() -> None:
+    script = _service()._install_script()
+
+    assert 'sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" sh -c' in script
+    assert "https://setup.atuin.sh" in script
+    assert 'ln -sf "$TARGET_HOME/.atuin/bin/atuin" /usr/local/bin/atuin' in script
+    assert '[[ -d "$HOME/.atuin/bin" ]] && export PATH="$HOME/.atuin/bin:$PATH"' in script
+    assert (
+        'if [ -x "$HOME/.atuin/bin/atuin" ]; then eval "$($HOME/.atuin/bin/atuin init zsh)"; '
+        'elif command -v atuin >/dev/null 2>&1; then eval "$(atuin init zsh)"; fi'
+        in script
+    )
+
+
+def test_install_script_repairs_and_exposes_pyenv_for_target_user() -> None:
+    script = _service()._install_script()
+
+    assert 'install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.pyenv"' in script
+    assert 'git clone https://github.com/pyenv/pyenv.git "$TARGET_HOME/.pyenv"' in script
+    assert 'git -C "$TARGET_HOME/.pyenv" init' in script
+    assert 'git -C "$TARGET_HOME/.pyenv" fetch --depth 1 origin master' in script
+    assert 'git -C "$TARGET_HOME/.pyenv" checkout -f FETCH_HEAD' in script
+    assert 'ln -sf "$TARGET_HOME/.pyenv/bin/pyenv" /usr/local/bin/pyenv' in script
+    assert '[[ -d "$PYENV_ROOT/bin" ]] && export PATH="$PYENV_ROOT/bin:$PATH"' in script
+    assert (
+        '[[ -d "$PYENV_ROOT/shims" ]] && export PATH="$PYENV_ROOT/shims:$PATH"'
+        in script
+    )
+    assert 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init -)"' in script
+
+
+def test_install_script_configures_utf8_locale_for_zsh_and_pyenv() -> None:
+    script = _service()._install_script()
+
+    assert "locales" in script
+    assert "locale-gen C.UTF-8" in script
+    assert "update-locale LANG=C.UTF-8 LC_CTYPE=C.UTF-8" in script
+    assert "append_once 'export LANG=C.UTF-8'" in script
+    assert "append_once 'export LC_CTYPE=C.UTF-8'" in script
+    assert "append_once 'unset LC_ALL'" in script

--- a/tests/unit/test_service_configs.py
+++ b/tests/unit/test_service_configs.py
@@ -293,6 +293,29 @@ def test_builtin_service_configs_have_matching_explicit_capabilities():
         assert config.service_capabilities() <= class_capabilities, config.path
 
 
+def test_dev_terminal_supports_kubernetes_agent_backends():
+    configs = {
+        config.id: config for config in load_all_service_configs(include_plugins=False)
+    }
+
+    config = configs["dev-terminal-0.1-beta"]
+
+    assert config.backend_capabilities() == {
+        "native",
+        "docker",
+        "kubernetes",
+        "kubernetes_agent",
+        "k3s_agent",
+    }
+    assert set(config.groups["backend"]) == {
+        "native",
+        "docker",
+        "kubernetes",
+        "kubernetes-agent",
+        "k3s-agent",
+    }
+
+
 @pytest.mark.parametrize(
     "config_id",
     [

--- a/tests/unit/tui/test_template_panel.py
+++ b/tests/unit/tui/test_template_panel.py
@@ -88,6 +88,9 @@ async def _service_template_ids_for_bundle(monkeypatch) -> tuple[int, set[str]]:
             "portable-service", "Portable Service", {"docker", "kubernetes"}
         ),
         _fake_service_config("k8s-service", "Kubernetes Service", {"kubernetes"}),
+        _fake_service_config(
+            "agent-service", "Agent Service", {"kubernetes_agent", "k3s_agent"}
+        ),
     ]
     monkeypatch.setattr(
         "mlox.tui.screens.dashboard.template_panel.load_all_service_configs",
@@ -112,3 +115,39 @@ def test_service_templates_are_filtered_by_bundle_backend(monkeypatch) -> None:
 
     assert row_count == 2
     assert config_ids == {"docker-service", "portable-service"}
+
+
+async def _service_template_ids_for_agent_bundle(
+    monkeypatch,
+) -> tuple[int, set[str]]:
+    configs = [
+        _fake_service_config("k8s-service", "Kubernetes Service", {"kubernetes"}),
+        _fake_service_config(
+            "agent-service", "Agent Service", {"kubernetes_agent", "k3s_agent"}
+        ),
+    ]
+    monkeypatch.setattr(
+        "mlox.tui.screens.dashboard.template_panel.load_all_service_configs",
+        lambda: configs,
+    )
+
+    app = TemplatePanelTestApp("service")
+    async with app.run_test() as pilot:
+        panel = app.query_one(TemplatePanel)
+        panel.selection = SelectionInfo(
+            type="bundle",
+            bundle=SimpleNamespace(
+                server=SimpleNamespace(backend=["kubernetes-agent", "k3s-agent"])
+            ),
+        )
+        await pilot.pause()
+        return panel.table.row_count, set(panel._configs_by_key)
+
+
+def test_service_templates_match_normalized_agent_backends(monkeypatch) -> None:
+    row_count, config_ids = asyncio.run(
+        _service_template_ids_for_agent_bundle(monkeypatch)
+    )
+
+    assert row_count == 1
+    assert config_ids == {"agent-service"}

--- a/wiki/Services-Catalog.md
+++ b/wiki/Services-Catalog.md
@@ -120,7 +120,7 @@ A reference to the ML/AI infrastructure services and integrations currently incl
 
 | Service | Version(s) | Description | Status |
 |---------|-----------|-------------|--------|
-| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, Atuin, Midnight Commander, Yazi, Claude Code, Spaceship prompt, OpenSSH, git, and useful terminal utilities. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
+| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, Atuin, Midnight Commander, Yazi, Claude Code, Spaceship prompt, git, pyenv-based Python version management, and useful terminal utilities; OpenSSH is expected from the MLOX server bootstrap. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
 
 ---
 

--- a/wiki/Services-Catalog.md
+++ b/wiki/Services-Catalog.md
@@ -16,7 +16,8 @@ A reference to the ML/AI infrastructure services and integrations currently incl
 8. [Kubernetes Add-ons](#kubernetes-add-ons)
 9. [Cloud Integrations](#cloud-integrations)
 10. [Source Control](#source-control)
-11. [Applications](#applications)
+11. [Developer Tools](#developer-tools)
+12. [Applications](#applications)
 
 ---
 
@@ -112,6 +113,14 @@ A reference to the ML/AI infrastructure services and integrations currently incl
 | Service | Version(s) | Description | Status |
 |---------|-----------|-------------|--------|
 | **GitHub Repository** | 0.1-beta | Clone and pull GitHub repositories onto managed servers. | Beta |
+
+---
+
+## Developer Tools
+
+| Service | Version(s) | Description | Status |
+|---------|-----------|-------------|--------|
+| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, Atuin, Midnight Commander, Yazi, Claude Code, Spaceship prompt, OpenSSH, git, and useful terminal utilities. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
 
 ---
 

--- a/wiki/Services-Catalog.md
+++ b/wiki/Services-Catalog.md
@@ -120,7 +120,7 @@ A reference to the ML/AI infrastructure services and integrations currently incl
 
 | Service | Version(s) | Description | Status |
 |---------|-----------|-------------|--------|
-| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, Atuin, Midnight Commander, Yazi, Claude Code, Spaceship prompt, git, pyenv-based Python version management, and useful terminal utilities; OpenSSH is expected from the MLOX server bootstrap. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
+| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, Atuin, Midnight Commander, Yazi, LazyVim integrations for Yazi and Claude Code, Spaceship prompt, git, pyenv-based Python version management, and useful terminal utilities; OpenSSH is expected from the MLOX server bootstrap. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
 
 ---
 


### PR DESCRIPTION
### Motivation
- Provide a one-step MLOX service to bootstrap a terminal-first developer workstation on remote Ubuntu backends. 
- Ensure common developer tools (LazyVim, `zsh`, Atuin, Midnight Commander, Yazi, Claude Code, Spaceship prompt, OpenSSH, `git`, and other utilities) are available for native hosts and also for Docker- and Kubernetes-capable backends that expose an Ubuntu host. 

### Description
- Add a new service package `mlox.services.dev_terminal` with `DeveloperTerminalService` that generates and runs an idempotent install script to provision developer tooling on the target host. 
- Add a service config `mlox.services.dev_terminal/mlox.dev_terminal.yaml` that advertises the service as `dev-terminal-0.1-beta` and declares compatibility with `native`, `docker`, and `kubernetes` backends. 
- Register a new `ServiceCapability.DEVELOPER_TOOLS` enum value and add `developer_tools` / `developer-tools` aliases in the capability mapping so the service can be grouped and discovered consistently. 
- Update the services catalog `wiki/Services-Catalog.md` to include a Developer Tools section documenting the new service. 

### Testing
- Confirmed the new service config is discoverable by calling `load_all_service_configs` and asserting `dev-terminal-0.1-beta` is present. 
- Compiled the affected Python modules with `python -m compileall` for `mlox/services/dev_terminal/service.py`, `mlox/service.py`, and `mlox/config.py` without errors. 
- Ran the integration registry test file (`pytest tests/integration/test_service_registry.py -q`), which reported tests as skipped because integration tests are disabled in the current environment. 
- Performed a basic runtime import/exercise of the new service to ensure it loads and the service capability is reported correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32531545548322aa94340e5f373427)