### PR TITLE
Introduce service templating, move manifests to templates, and add tests/fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ mlox/
 │   └── executors.py    # Remote task executor layer used by services/servers
 ├── tests/
 │   ├── unit/           # Fast tests, no external deps
-│   └── integration/    # Multipass VM tests
+│   └── integration/    # Multipass VM tests, including Kubernetes/k3s tests
 ├── examples/           # OTel, MLflow tracking, DAG templates
 ├── docs/               # Architecture, installation, contribution guides
 ├── wiki/               # GitHub Wiki source pages
@@ -188,6 +188,7 @@ pip install -e .[dev]
 task dev:lint                   # flake8
 task tests:unit:run             # unit tests (fast, no external deps)
 task tests:integration:run      # integration tests (requires Multipass VMs)
+task tests:integration:k8s      # Kubernetes integration tests (requires Multipass/k3s)
 ```
 
 ### Ways to Contribute

--- a/docs/ARCHITECTURE_AGENTS.md
+++ b/docs/ARCHITECTURE_AGENTS.md
@@ -77,5 +77,9 @@ Integration tests require Multipass:
 
 ```bash
 task tests:integration:run
+task tests:integration:k8s
 task tests:integration:cleanup
 ```
+
+`tests:integration:k8s` runs only tests marked with both `integration` and
+`kubernetes`; these provision a Multipass/k3s backend.

--- a/docs/ARCHITECTURE_HUMANS.md
+++ b/docs/ARCHITECTURE_HUMANS.md
@@ -111,8 +111,12 @@ task
 task first:steps
 task tests:unit:run
 task tests:integration:run
+task tests:integration:k8s
 task docker:up
 task docker:down
 ```
 
-Unit tests live in `tests/unit/`. Integration tests live in `tests/integration/` and require Multipass.
+Unit tests live in `tests/unit/`. Integration tests live in `tests/integration/`
+and require Multipass. Kubernetes integration tests are selected with
+`task tests:integration:k8s`, which runs tests marked with both `integration`
+and `kubernetes`.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -58,6 +58,15 @@ For running all integration tests just type (assumes multipass VM has been insta
 task tests:integration:run
 ```
 
+For running only the Kubernetes integration tests, which provision a k3s-backed
+Multipass VM and run tests marked with both `integration` and `kubernetes`:
+
+```bash
+task tests:integration:k8s
+# alias:
+task tests:integration:kubernetes
+```
+
 For running a specific integration test use:
 
 ```bash
@@ -71,6 +80,7 @@ task vm:install:macos      # macOS only
 task vm:install:linux      # Linux only
 task vm:start
 task tests:integration:run
+task tests:integration:k8s
 task tests:integration:cleanup
 task vm:purge
 ```

--- a/docs/WORKFLOW_QUICK_REFERENCE.md
+++ b/docs/WORKFLOW_QUICK_REFERENCE.md
@@ -22,6 +22,7 @@ task
 task first:steps
 task tests:unit:run
 task tests:integration:run
+task tests:integration:k8s
 task docker:up
 task docker:down
 task ui:streamlit

--- a/mlox/infra.py
+++ b/mlox/infra.py
@@ -95,16 +95,6 @@ class Infrastructure:
                 return bundle
         return None
 
-    def remove_bundle(self, bundle: Bundle) -> bool:
-        """Remove a bundle from the infrastructure if it is present."""
-
-        try:
-            self.bundles.remove(bundle)
-            return True
-        except ValueError:
-            logger.warning("Bundle %s was not present in infrastructure.", bundle.name)
-            return False
-
     def list_service_names(self) -> List[str]:
         return [s.name for bundle in self.bundles for s in bundle.services]
 

--- a/mlox/infra.py
+++ b/mlox/infra.py
@@ -95,6 +95,16 @@ class Infrastructure:
                 return bundle
         return None
 
+    def remove_bundle(self, bundle: Bundle) -> bool:
+        """Remove a bundle from the infrastructure if it is present."""
+
+        try:
+            self.bundles.remove(bundle)
+            return True
+        except ValueError:
+            logger.warning("Bundle %s was not present in infrastructure.", bundle.name)
+            return False
+
     def list_service_names(self) -> List[str]:
         return [s.name for bundle in self.bundles for s in bundle.services]
 

--- a/mlox/server.py
+++ b/mlox/server.py
@@ -145,8 +145,7 @@ class ServerConnection:
             socket.timeout,  # General socket timeout
             NoValidConnectionsError,  # If all resolved IPs for a host fail connection
             EOFError,  # Can sometimes be transient network drop
-            # SSHException can be broad; if specific transient SSH errors are known, list them.
-            # Avoid retrying AuthenticationException or issues due to bad host configuration here.
+            SSHException,  # Covers transient SSH banner resets while sshd restarts.
         )
 
         while current_attempt <= self.retries:
@@ -182,6 +181,17 @@ class ServerConnection:
                 )
                 return self._conn
             except (
+                socket.gaierror,
+                AuthenticationException,
+            ) as e:  # Non-retryable errors
+                logging.error(
+                    f"Non-retryable error connecting to {host}: {type(e).__name__} - {e}"
+                )
+                if self._tmp_dir:
+                    close_connection(None, self._tmp_dir)
+                    self._tmp_dir = None
+                raise  # Re-raise immediately, do not retry
+            except (
                 RETRYABLE_EXCEPTIONS_FOR_CONNECTION
             ) as e:  # Catch only specified retryable exceptions
                 logging.warning(
@@ -201,17 +211,6 @@ class ServerConnection:
                     )
                 time.sleep(self.retry_delay)
                 current_attempt += 1
-            except (
-                socket.gaierror,
-                AuthenticationException,
-            ) as e:  # Non-retryable errors
-                logging.error(
-                    f"Non-retryable error connecting to {host}: {type(e).__name__} - {e}"
-                )
-                if self._tmp_dir:
-                    close_connection(None, self._tmp_dir)
-                    self._tmp_dir = None
-                raise  # Re-raise immediately, do not retry
             except (
                 Exception
             ) as e:  # Catch any other unexpected errors during connection setup

--- a/mlox/server.py
+++ b/mlox/server.py
@@ -201,6 +201,9 @@ class ServerConnection:
                 )
                 if current_attempt == self.retries:
                     logging.error(f"Max connection retries reached for {host}.")
+                    if self._tmp_dir:
+                        close_connection(None, self._tmp_dir)
+                        self._tmp_dir = None
                     raise
                 logging.info(f"Retrying connection in {self.retry_delay} seconds...")
                 if self._tmp_dir:  # Clean up temp dir if connection failed partway

--- a/mlox/service.py
+++ b/mlox/service.py
@@ -21,16 +21,38 @@ import io
 import csv
 import json
 import uuid
+import string
+import inspect
 import logging
+import textwrap
+from pathlib import Path
 from datetime import datetime
 from abc import ABC, abstractmethod
 from enum import StrEnum
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Literal, Optional, Protocol
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Protocol,
+)
 from dataclasses import dataclass, field, asdict
 
 from mlox.executors import UbuntuTaskExecutor
 
 logger = logging.getLogger(__name__)
+
+
+class MloxTemplate(string.Template):
+    """Simple service artifact template using ``@variable`` placeholders."""
+
+    delimiter = "@"
+    idpattern = r"[_a-zA-Z][_a-zA-Z0-9]*"
+
 
 if TYPE_CHECKING:
     from mlox.infra import Infrastructure
@@ -168,6 +190,62 @@ class AbstractService(ABC):
 
     def clear_service_lookup(self) -> None:
         self._service_lookup = None
+
+    def service_dir(self) -> Path:
+        """Return the directory containing the concrete service implementation."""
+
+        return Path(inspect.getfile(type(self))).resolve().parent
+
+    def render_template(
+        self, template_name: str, variables: Mapping[str, Any]
+    ) -> str:
+        """Render a service-local template with explicit ``@variable`` values.
+
+        Templates are resolved relative to the concrete service implementation
+        module, so service artifacts can live next to ``k8s.py``, ``docker.py``,
+        and the service ``mlox.*.yaml`` descriptor.
+        """
+
+        template_path = self.service_dir() / template_name
+        if not template_path.is_file():
+            raise FileNotFoundError(f"Template not found: {template_path}")
+
+        template = MloxTemplate(template_path.read_text(encoding="utf-8"))
+        try:
+            return template.substitute(dict(variables))
+        except KeyError as exc:
+            missing = exc.args[0]
+            raise KeyError(
+                f"Missing template variable {missing!r} while rendering "
+                f"{template_path}"
+            ) from exc
+        except ValueError as exc:
+            raise ValueError(f"Invalid template syntax in {template_path}: {exc}") from exc
+
+    def render_template_to_file(
+        self,
+        conn,
+        template_name: str,
+        remote_path: str,
+        variables: Mapping[str, Any],
+    ) -> str:
+        """Render a service-local template and write it to a remote path."""
+
+        rendered = self.render_template(template_name, variables)
+        self.exec.fs_write_file(conn, remote_path, rendered)
+        return rendered
+
+    @staticmethod
+    def yaml_scalar(value: Any) -> str:
+        """Return a safe one-line YAML scalar representation."""
+
+        return json.dumps(value)
+
+    @staticmethod
+    def indent_block(value: str, spaces: int) -> str:
+        """Indent a multiline block for embedding in YAML block scalars."""
+
+        return textwrap.indent(value.rstrip(), " " * spaces)
 
     @abstractmethod
     def setup(self, conn) -> None:

--- a/mlox/services/dev_terminal/cleanup-sensitive-state.sh.tmpl
+++ b/mlox/services/dev_terminal/cleanup-sensitive-state.sh.tmpl
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_USER="${SUDO_USER:-$(id -un)}"
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
+  TARGET_HOME="$HOME"
+fi
+
+remove_home_path() {
+  local relative_path="$1"
+  if [[ -z "$relative_path" ||
+        "$relative_path" == /* ||
+        "$relative_path" == ".." ||
+        "$relative_path" == ../* ||
+        "$relative_path" == */.. ||
+        "$relative_path" == */../* ]]; then
+    echo "Refusing to remove unsafe relative path: $relative_path" >&2
+    return 1
+  fi
+  rm -rf -- "$TARGET_HOME/$relative_path"
+}
+
+# Claude Code stores authentication, session metadata, project transcripts,
+# settings, and cache/state under these user-level paths depending on version.
+remove_home_path ".claude"
+remove_home_path ".claude.json"
+remove_home_path ".claude.json.backup"
+remove_home_path ".config/claude"
+remove_home_path ".config/claude-code"
+remove_home_path ".cache/claude"
+remove_home_path ".cache/claude-code"
+remove_home_path ".local/share/claude"
+remove_home_path ".local/share/claude-code"
+remove_home_path ".local/state/claude"
+remove_home_path ".local/state/claude-code"
+
+# Atuin stores shell history, which can include pasted tokens and credentials.
+remove_home_path ".atuin"
+remove_home_path ".config/atuin"
+remove_home_path ".local/share/atuin"
+remove_home_path ".local/state/atuin"
+
+# Service-generated terminal manager files do not contain credentials, but
+# removing them prevents stale aliases/configuration after service teardown.
+remove_home_path ".tmux.conf"
+remove_home_path ".tmux-shortcuts"

--- a/mlox/services/dev_terminal/install-developer-terminal.sh.tmpl
+++ b/mlox/services/dev_terminal/install-developer-terminal.sh.tmpl
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+INSTALL_CLAUDE_CODE=@install_claude_code
+INSTALL_ATUIN=@install_atuin
+INSTALL_LAZYVIM=@install_lazyvim
+INSTALL_YAZI=@install_yazi
+INSTALL_SPACESHIP=@install_spaceship
+INSTALL_PYENV=@install_pyenv
+INSTALL_OH_MY_ZSH=@install_oh_my_zsh
+MIN_NVIM_VERSION=0.11.2
+TARGET_USER="${SUDO_USER:-$(id -un)}"
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
+  TARGET_HOME="$HOME"
+fi
+
+apt-get update
+apt-get install -yq \
+  bash bat btop build-essential ca-certificates curl direnv fd-find fzf git \
+  gnupg gzip htop jq libbz2-dev libffi-dev liblzma-dev libncursesw5-dev \
+  libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxmlsec1-dev \
+  llvm locales lsb-release make mc ncurses-bin ncurses-term nodejs npm pipx python3 \
+  python3-pip ripgrep snapd tar tk-dev tmux unzip wget xz-utils \
+  zlib1g-dev zsh
+
+locale-gen C.UTF-8 >/dev/null 2>&1 || true
+update-locale LANG=C.UTF-8 LC_CTYPE=C.UTF-8 >/dev/null 2>&1 || true
+
+# Ubuntu/Debian package names the fd and bat binaries differently.
+ln -sf /usr/bin/fdfind /usr/local/bin/fd 2>/dev/null || true
+ln -sf /usr/bin/batcat /usr/local/bin/bat 2>/dev/null || true
+
+nvim_version() {
+  if command -v nvim >/dev/null 2>&1; then
+    nvim --version | sed -n '1s/^NVIM v//p' | cut -d- -f1
+  fi
+}
+
+nvim_version_meets_min() {
+  local version
+  version="$(nvim_version)"
+  [ -n "$version" ] && dpkg --compare-versions "$version" ge "$MIN_NVIM_VERSION"
+}
+
+if ! nvim_version_meets_min; then
+  systemctl enable --now snapd.socket >/dev/null 2>&1 || true
+  snap wait system seed.loaded >/dev/null 2>&1 || true
+  snap install nvim --classic
+  if [ -x /snap/bin/nvim ]; then
+    ln -sf /snap/bin/nvim /usr/local/bin/nvim
+  fi
+fi
+
+if ! nvim_version_meets_min; then
+  echo "Neovim $MIN_NVIM_VERSION or newer is required for LazyVim." >&2
+  exit 1
+fi
+
+npm install -g neovim tree-sitter-cli || true
+if [ "$INSTALL_CLAUDE_CODE" = true ]; then
+  npm install -g @@anthropic-ai/claude-code || true
+fi
+if [ "$INSTALL_SPACESHIP" = true ]; then
+  npm install -g spaceship-prompt || true
+fi
+
+if [ "$INSTALL_ATUIN" = true ] && ! command -v atuin >/dev/null 2>&1 && [ ! -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
+  sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" sh -c \
+    "curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh" || true
+  if [ -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
+    ln -sf "$TARGET_HOME/.atuin/bin/atuin" /usr/local/bin/atuin
+  fi
+fi
+
+if [ "$INSTALL_YAZI" = true ] && ! command -v yazi >/dev/null 2>&1; then
+  tmpdir="$(mktemp -d)"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64) yazi_arch="x86_64-unknown-linux-gnu" ;;
+    aarch64|arm64) yazi_arch="aarch64-unknown-linux-gnu" ;;
+    *) yazi_arch="" ;;
+  esac
+  if [ -n "$yazi_arch" ]; then
+    curl -fsSL "https://github.com/sxyazi/yazi/releases/latest/download/yazi-${yazi_arch}.zip" -o "$tmpdir/yazi.zip" || true
+    if [ -s "$tmpdir/yazi.zip" ]; then
+      unzip -q "$tmpdir/yazi.zip" -d "$tmpdir"
+      find "$tmpdir" -type f -name yazi -exec install -m 0755 {} /usr/local/bin/yazi \; -quit
+      find "$tmpdir" -type f -name ya -exec install -m 0755 {} /usr/local/bin/ya \; -quit
+    fi
+  fi
+  rm -rf "$tmpdir"
+fi
+
+if [ "$INSTALL_PYENV" = true ]; then
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.pyenv"
+  if [ ! -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
+    if [ -d "$TARGET_HOME/.pyenv/.git" ]; then
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" pull --ff-only || true
+    elif [ -z "$(find "$TARGET_HOME/.pyenv" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git clone https://github.com/pyenv/pyenv.git "$TARGET_HOME/.pyenv" || true
+    else
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" init || true
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" remote add origin https://github.com/pyenv/pyenv.git 2>/dev/null || \
+        sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" remote set-url origin https://github.com/pyenv/pyenv.git || true
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" fetch --depth 1 origin master || true
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" checkout -f FETCH_HEAD || true
+    fi
+  fi
+  chown -R "$TARGET_USER:$TARGET_USER" "$TARGET_HOME/.pyenv" || true
+  if [ -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
+    ln -sf "$TARGET_HOME/.pyenv/bin/pyenv" /usr/local/bin/pyenv
+  fi
+fi
+
+if [ "$INSTALL_OH_MY_ZSH" = true ]; then
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.oh-my-zsh"
+  if [ ! -f "$TARGET_HOME/.oh-my-zsh/oh-my-zsh.sh" ]; then
+    if [ -d "$TARGET_HOME/.oh-my-zsh/.git" ]; then
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.oh-my-zsh" pull --ff-only || true
+    elif [ -z "$(find "$TARGET_HOME/.oh-my-zsh" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git clone --depth 1 https://github.com/ohmyzsh/ohmyzsh.git "$TARGET_HOME/.oh-my-zsh" || true
+    fi
+  fi
+  chown -R "$TARGET_USER:$TARGET_USER" "$TARGET_HOME/.oh-my-zsh" || true
+fi
+
+if [ "$INSTALL_LAZYVIM" = true ]; then
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config"
+  if [ ! -d "$TARGET_HOME/.config/nvim" ]; then
+    sudo -u "$TARGET_USER" git clone https://github.com/LazyVim/starter "$TARGET_HOME/.config/nvim" || true
+    rm -rf "$TARGET_HOME/.config/nvim/.git"
+  fi
+
+  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config/nvim/lua/plugins"
+  NVIM_PLUGIN="$TARGET_HOME/.config/nvim/lua/plugins/mlox-dev-terminal.lua"
+  cat > "$NVIM_PLUGIN" <<'MLOX_LAZYVIM_DEV_TERMINAL'
+-- MLOX Developers Terminal Dream: Claude Code and Yazi integrations for LazyVim.
+return {
+  {
+    "coder/claudecode.nvim",
+    opts = {},
+    keys = {
+      { "<leader>a", "", desc = "+ai", mode = { "n", "v" } },
+      { "<leader>ac", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude" },
+      { "<leader>af", "<cmd>ClaudeCodeFocus<cr>", desc = "Focus Claude" },
+      { "<leader>ar", "<cmd>ClaudeCode --resume<cr>", desc = "Resume Claude" },
+      { "<leader>aC", "<cmd>ClaudeCode --continue<cr>", desc = "Continue Claude" },
+      { "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>", desc = "Add current buffer" },
+      { "<leader>as", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" },
+      { "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" },
+      { "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" },
+    },
+  },
+  {
+    "mikavilpas/yazi.nvim",
+    version = "*",
+    event = "VeryLazy",
+    dependencies = {
+      { "nvim-lua/plenary.nvim", lazy = true },
+    },
+    keys = {
+      { "<leader>-", "<cmd>Yazi<cr>", mode = { "n", "v" }, desc = "Open yazi at the current file" },
+      { "<leader>cw", "<cmd>Yazi cwd<cr>", desc = "Open yazi in nvim cwd" },
+      { "<c-up>", "<cmd>Yazi toggle<cr>", desc = "Resume yazi" },
+    },
+    opts = {
+      open_for_directories = true,
+      open_multiple_tabs = true,
+      keymaps = {
+        show_help = "<f1>",
+      },
+    },
+    init = function()
+      vim.g.loaded_netrwPlugin = 1
+    end,
+  },
+}
+MLOX_LAZYVIM_DEV_TERMINAL
+  chown "$TARGET_USER:$TARGET_USER" "$NVIM_PLUGIN" || true
+fi
+
+TMUX_CONF="$TARGET_HOME/.tmux.conf"
+cat > "$TMUX_CONF" <<'MLOX_TMUX_CONF'
+# MLOX Developer Terminal tmux defaults for LazyVim/Neovim.
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*:RGB"
+set -ga terminal-overrides ",xterm-256color:Tc"
+set -ga terminal-overrides ",alacritty:Tc"
+set -ga terminal-overrides ",wezterm:Tc"
+set -ga terminal-overrides ",xterm-kitty:Tc"
+set -g focus-events on
+set -g escape-time 10
+set -g repeat-time 600
+set -g renumber-windows on
+set -g base-index 1
+setw -g pane-base-index 1
+set -g mouse on
+setw -g mode-keys vi
+set -g set-clipboard on
+set -g history-limit 100000
+set -g status-position bottom
+set -g status-interval 5
+set -g status-style "bg=colour235,fg=colour250"
+set -g window-status-current-style "bg=colour31,fg=colour255,bold"
+set -g pane-border-style "fg=colour238"
+set -g pane-active-border-style "fg=colour39"
+set -g message-style "bg=colour31,fg=colour255"
+
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+bind r source-file ~/.tmux.conf \; display-message "Reloaded ~/.tmux.conf"
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 3
+bind -r K resize-pane -U 3
+bind -r L resize-pane -R 5
+bind-key -T copy-mode-vi v send -X begin-selection
+bind-key -T copy-mode-vi y send -X copy-selection-and-cancel
+bind ? display-popup -E -w 78 -h 24 "cat ~/.tmux-shortcuts"
+MLOX_TMUX_CONF
+chown "$TARGET_USER:$TARGET_USER" "$TMUX_CONF" || true
+
+TMUX_SHORTCUTS="$TARGET_HOME/.tmux-shortcuts"
+cat > "$TMUX_SHORTCUTS" <<'MLOX_TMUX_SHORTCUTS'
+tmux essentials for this host
+
+Start or attach:
+  tmux new -As dev
+
+Prefix:
+  Ctrl-a        prefix key
+  Ctrl-a r      reload ~/.tmux.conf
+  Ctrl-a ?      show this shortcut sheet
+
+Windows:
+  Ctrl-a c      new window
+  Ctrl-a n/p    next/previous window
+  Ctrl-a 1..9   switch to window
+  Ctrl-a ,      rename window
+
+Panes:
+  Ctrl-a |      split right
+  Ctrl-a -      split down
+  Ctrl-a h/j/k/l move between panes
+  Ctrl-a H/J/K/L resize pane
+  Ctrl-a z      zoom pane
+
+Copy mode:
+  Ctrl-a [      enter copy mode
+  v             start selection
+  y             copy selection
+  q             quit copy mode
+MLOX_TMUX_SHORTCUTS
+chown "$TARGET_USER:$TARGET_USER" "$TMUX_SHORTCUTS" || true
+
+ZSHRC="$TARGET_HOME/.zshrc"
+touch "$ZSHRC"
+chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
+append_once() {
+  local line="$1"
+  grep -qxF "$line" "$ZSHRC" 2>/dev/null || echo "$line" >> "$ZSHRC"
+}
+remove_line() {
+  local line="$1"
+  if [ -f "$ZSHRC" ]; then
+    grep -vxF "$line" "$ZSHRC" > "$ZSHRC.tmp" 2>/dev/null || true
+    cat "$ZSHRC.tmp" > "$ZSHRC"
+    rm -f "$ZSHRC.tmp"
+  fi
+}
+remove_line '[ -x "$HOME/.atuin/bin/atuin" ] && eval "$($HOME/.atuin/bin/atuin init zsh)"'
+remove_line 'command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"'
+remove_line '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+remove_line 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init - zsh)"'
+append_once 'export EDITOR=nvim'
+append_once 'export VISUAL=nvim'
+append_once 'export LANG=C.UTF-8'
+append_once 'export LC_CTYPE=C.UTF-8'
+append_once 'export COLORTERM=truecolor'
+append_once 'export TERMINFO_DIRS="$HOME/.terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo"'
+append_once 'export NCURSES_NO_UTF8_ACS=1'
+append_once 'export LESSCHARSET=utf-8'
+append_once 'unset LC_ALL'
+append_once 'export PYENV_ROOT="$HOME/.pyenv"'
+append_once '[[ -d "$PYENV_ROOT/bin" ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
+append_once '[[ -d "$PYENV_ROOT/shims" ]] && export PATH="$PYENV_ROOT/shims:$PATH"'
+append_once '[[ -d "$HOME/.atuin/bin" ]] && export PATH="$HOME/.atuin/bin:$PATH"'
+append_once 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init -)"'
+append_once 'alias ll="ls -lah"'
+append_once 'alias vim="nvim"'
+append_once 'alias vi="nvim"'
+append_once 'alias fm="yazi"'
+append_once 'alias mux="tmux new -As dev"'
+append_once 'alias tmux-help="cat ~/.tmux-shortcuts"'
+append_once 'eval "$(direnv hook zsh)"'
+append_once 'if [ -x "$HOME/.atuin/bin/atuin" ]; then eval "$($HOME/.atuin/bin/atuin init zsh)"; elif command -v atuin >/dev/null 2>&1; then eval "$(atuin init zsh)"; fi'
+append_once 'export ZSH="$HOME/.oh-my-zsh"'
+append_once 'ZSH_THEME=""'
+append_once 'plugins=(git direnv fzf pyenv)'
+append_once '[ -f "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"'
+append_once '[ -f "$(npm root -g 2>/dev/null)/spaceship-prompt/spaceship.zsh" ] && source "$(npm root -g)/spaceship-prompt/spaceship.zsh"'
+chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
+
+if command -v zsh >/dev/null 2>&1; then
+  chsh -s "$(command -v zsh)" "$TARGET_USER" || true
+fi

--- a/mlox/services/dev_terminal/mlox.dev_terminal.yaml
+++ b/mlox/services/dev_terminal/mlox.dev_terminal.yaml
@@ -5,8 +5,9 @@ maintainer: Busy Sloths
 description_short: Install a terminal-first developer workstation on MLOX backends.
 description: 'Developers Terminal Dream turns a remote backend into a comfortable
   terminal developer machine. It installs and configures LazyVim, zsh, Atuin shell
-  history, Midnight Commander, Yazi, LazyVim integrations for Yazi and Claude Code, Spaceship prompt, git, pyenv,
-  and practical terminal utilities. OpenSSH is expected to come from the MLOX
+  history, Midnight Commander, Yazi, tmux, oh-my-zsh, LazyVim integrations for
+  Yazi and Claude Code, Spaceship prompt, git, pyenv, and practical terminal
+  utilities. OpenSSH is expected to come from the MLOX
   server bootstrap. Although it is implemented as a native host
   bootstrapper, it also fits Docker and Kubernetes-capable Ubuntu backends because
   those backends expose the same remote host where developers run shells and tools.

--- a/mlox/services/dev_terminal/service.py
+++ b/mlox/services/dev_terminal/service.py
@@ -24,226 +24,25 @@ class DeveloperTerminalService(AbstractService):
     install_yazi: bool = True
     install_spaceship: bool = True
     install_pyenv: bool = True
+    install_oh_my_zsh: bool = True
     installed_tools: list[str] = field(default_factory=list, init=False)
 
     def _install_script(self) -> str:
-        claude = "true" if self.install_claude_code else "false"
-        atuin = "true" if self.install_atuin else "false"
-        lazyvim = "true" if self.install_lazyvim else "false"
-        yazi = "true" if self.install_yazi else "false"
-        spaceship = "true" if self.install_spaceship else "false"
-        pyenv = "true" if self.install_pyenv else "false"
-        return f"""#!/usr/bin/env bash
-set -euo pipefail
-export DEBIAN_FRONTEND=noninteractive
-INSTALL_CLAUDE_CODE={claude}
-INSTALL_ATUIN={atuin}
-INSTALL_LAZYVIM={lazyvim}
-INSTALL_YAZI={yazi}
-INSTALL_SPACESHIP={spaceship}
-INSTALL_PYENV={pyenv}
-MIN_NVIM_VERSION=0.11.2
-TARGET_USER="${{SUDO_USER:-$(id -un)}}"
-TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
-if [ -z "$TARGET_HOME" ] || [ ! -d "$TARGET_HOME" ]; then
-  TARGET_HOME="$HOME"
-fi
+        return self.render_template(
+            "install-developer-terminal.sh.tmpl",
+            {
+                "install_claude_code": str(self.install_claude_code).lower(),
+                "install_atuin": str(self.install_atuin).lower(),
+                "install_lazyvim": str(self.install_lazyvim).lower(),
+                "install_yazi": str(self.install_yazi).lower(),
+                "install_spaceship": str(self.install_spaceship).lower(),
+                "install_pyenv": str(self.install_pyenv).lower(),
+                "install_oh_my_zsh": str(self.install_oh_my_zsh).lower(),
+            },
+        )
 
-apt-get update
-apt-get install -yq \
-  bash bat btop build-essential ca-certificates curl direnv fd-find fzf git \
-  gnupg gzip htop jq libbz2-dev libffi-dev liblzma-dev libncursesw5-dev \
-  libreadline-dev libsqlite3-dev libssl-dev libxml2-dev libxmlsec1-dev \
-  llvm locales lsb-release make mc nodejs npm pipx python3 python3-pip \
-  ripgrep snapd tar tk-dev tmux unzip wget xz-utils zlib1g-dev zsh
-
-locale-gen C.UTF-8 >/dev/null 2>&1 || true
-update-locale LANG=C.UTF-8 LC_CTYPE=C.UTF-8 >/dev/null 2>&1 || true
-
-# Ubuntu/Debian package names the fd and bat binaries differently.
-ln -sf /usr/bin/fdfind /usr/local/bin/fd 2>/dev/null || true
-ln -sf /usr/bin/batcat /usr/local/bin/bat 2>/dev/null || true
-
-nvim_version() {{
-  if command -v nvim >/dev/null 2>&1; then
-    nvim --version | sed -n '1s/^NVIM v//p' | cut -d- -f1
-  fi
-}}
-
-nvim_version_meets_min() {{
-  local version
-  version="$(nvim_version)"
-  [ -n "$version" ] && dpkg --compare-versions "$version" ge "$MIN_NVIM_VERSION"
-}}
-
-if ! nvim_version_meets_min; then
-  systemctl enable --now snapd.socket >/dev/null 2>&1 || true
-  snap wait system seed.loaded >/dev/null 2>&1 || true
-  snap install nvim --classic
-  if [ -x /snap/bin/nvim ]; then
-    ln -sf /snap/bin/nvim /usr/local/bin/nvim
-  fi
-fi
-
-if ! nvim_version_meets_min; then
-  echo "Neovim $MIN_NVIM_VERSION or newer is required for LazyVim." >&2
-  exit 1
-fi
-
-npm install -g neovim tree-sitter-cli || true
-if [ "$INSTALL_CLAUDE_CODE" = true ]; then
-  npm install -g @anthropic-ai/claude-code || true
-fi
-if [ "$INSTALL_SPACESHIP" = true ]; then
-  npm install -g spaceship-prompt || true
-fi
-
-if [ "$INSTALL_ATUIN" = true ] && ! command -v atuin >/dev/null 2>&1 && [ ! -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
-  sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" sh -c \
-    "curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh" || true
-  if [ -x "$TARGET_HOME/.atuin/bin/atuin" ]; then
-    ln -sf "$TARGET_HOME/.atuin/bin/atuin" /usr/local/bin/atuin
-  fi
-fi
-
-if [ "$INSTALL_YAZI" = true ] && ! command -v yazi >/dev/null 2>&1; then
-  tmpdir="$(mktemp -d)"
-  arch="$(uname -m)"
-  case "$arch" in
-    x86_64|amd64) yazi_arch="x86_64-unknown-linux-gnu" ;;
-    aarch64|arm64) yazi_arch="aarch64-unknown-linux-gnu" ;;
-    *) yazi_arch="" ;;
-  esac
-  if [ -n "$yazi_arch" ]; then
-    curl -fsSL "https://github.com/sxyazi/yazi/releases/latest/download/yazi-${{yazi_arch}}.zip" -o "$tmpdir/yazi.zip" || true
-    if [ -s "$tmpdir/yazi.zip" ]; then
-      unzip -q "$tmpdir/yazi.zip" -d "$tmpdir"
-      find "$tmpdir" -type f -name yazi -exec install -m 0755 {{}} /usr/local/bin/yazi \\; -quit
-      find "$tmpdir" -type f -name ya -exec install -m 0755 {{}} /usr/local/bin/ya \\; -quit
-    fi
-  fi
-  rm -rf "$tmpdir"
-fi
-
-
-if [ "$INSTALL_PYENV" = true ]; then
-  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.pyenv"
-  if [ ! -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
-    if [ -d "$TARGET_HOME/.pyenv/.git" ]; then
-      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" pull --ff-only || true
-    elif [ -z "$(find "$TARGET_HOME/.pyenv" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git clone https://github.com/pyenv/pyenv.git "$TARGET_HOME/.pyenv" || true
-    else
-      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" init || true
-      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" remote add origin https://github.com/pyenv/pyenv.git 2>/dev/null || \
-        sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" remote set-url origin https://github.com/pyenv/pyenv.git || true
-      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" fetch --depth 1 origin master || true
-      sudo -H -u "$TARGET_USER" env HOME="$TARGET_HOME" git -C "$TARGET_HOME/.pyenv" checkout -f FETCH_HEAD || true
-    fi
-  fi
-  chown -R "$TARGET_USER:$TARGET_USER" "$TARGET_HOME/.pyenv" || true
-  if [ -x "$TARGET_HOME/.pyenv/bin/pyenv" ]; then
-    ln -sf "$TARGET_HOME/.pyenv/bin/pyenv" /usr/local/bin/pyenv
-  fi
-fi
-
-if [ "$INSTALL_LAZYVIM" = true ]; then
-  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config"
-  if [ ! -d "$TARGET_HOME/.config/nvim" ]; then
-    sudo -u "$TARGET_USER" git clone https://github.com/LazyVim/starter "$TARGET_HOME/.config/nvim" || true
-    rm -rf "$TARGET_HOME/.config/nvim/.git"
-  fi
-
-  install -d -o "$TARGET_USER" -g "$TARGET_USER" "$TARGET_HOME/.config/nvim/lua/plugins"
-  NVIM_PLUGIN="$TARGET_HOME/.config/nvim/lua/plugins/mlox-dev-terminal.lua"
-  cat > "$NVIM_PLUGIN" <<'MLOX_LAZYVIM_DEV_TERMINAL'
--- MLOX Developers Terminal Dream: Claude Code and Yazi integrations for LazyVim.
-return {{
-  {{
-    "coder/claudecode.nvim",
-    opts = {{}},
-    keys = {{
-      {{ "<leader>a", "", desc = "+ai", mode = {{ "n", "v" }} }},
-      {{ "<leader>ac", "<cmd>ClaudeCode<cr>", desc = "Toggle Claude" }},
-      {{ "<leader>af", "<cmd>ClaudeCodeFocus<cr>", desc = "Focus Claude" }},
-      {{ "<leader>ar", "<cmd>ClaudeCode --resume<cr>", desc = "Resume Claude" }},
-      {{ "<leader>aC", "<cmd>ClaudeCode --continue<cr>", desc = "Continue Claude" }},
-      {{ "<leader>ab", "<cmd>ClaudeCodeAdd %<cr>", desc = "Add current buffer" }},
-      {{ "<leader>as", "<cmd>ClaudeCodeSend<cr>", mode = "v", desc = "Send to Claude" }},
-      {{ "<leader>aa", "<cmd>ClaudeCodeDiffAccept<cr>", desc = "Accept diff" }},
-      {{ "<leader>ad", "<cmd>ClaudeCodeDiffDeny<cr>", desc = "Deny diff" }},
-    }},
-  }},
-  {{
-    "mikavilpas/yazi.nvim",
-    version = "*",
-    event = "VeryLazy",
-    dependencies = {{
-      {{ "nvim-lua/plenary.nvim", lazy = true }},
-    }},
-    keys = {{
-      {{ "<leader>-", "<cmd>Yazi<cr>", mode = {{ "n", "v" }}, desc = "Open yazi at the current file" }},
-      {{ "<leader>cw", "<cmd>Yazi cwd<cr>", desc = "Open yazi in nvim cwd" }},
-      {{ "<c-up>", "<cmd>Yazi toggle<cr>", desc = "Resume yazi" }},
-    }},
-    opts = {{
-      open_for_directories = true,
-      open_multiple_tabs = true,
-      keymaps = {{
-        show_help = "<f1>",
-      }},
-    }},
-    init = function()
-      vim.g.loaded_netrwPlugin = 1
-    end,
-  }},
-}}
-MLOX_LAZYVIM_DEV_TERMINAL
-  chown "$TARGET_USER:$TARGET_USER" "$NVIM_PLUGIN" || true
-fi
-
-ZSHRC="$TARGET_HOME/.zshrc"
-touch "$ZSHRC"
-chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
-append_once() {{
-  local line="$1"
-  grep -qxF "$line" "$ZSHRC" 2>/dev/null || echo "$line" >> "$ZSHRC"
-}}
-remove_line() {{
-  local line="$1"
-  if [ -f "$ZSHRC" ]; then
-    grep -vxF "$line" "$ZSHRC" > "$ZSHRC.tmp" 2>/dev/null || true
-    cat "$ZSHRC.tmp" > "$ZSHRC"
-    rm -f "$ZSHRC.tmp"
-  fi
-}}
-remove_line '[ -x "$HOME/.atuin/bin/atuin" ] && eval "$($HOME/.atuin/bin/atuin init zsh)"'
-remove_line 'command -v atuin >/dev/null 2>&1 && eval "$(atuin init zsh)"'
-remove_line '[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-remove_line 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init - zsh)"'
-append_once 'export EDITOR=nvim'
-append_once 'export VISUAL=nvim'
-append_once 'export LANG=C.UTF-8'
-append_once 'export LC_CTYPE=C.UTF-8'
-append_once 'unset LC_ALL'
-append_once 'export PYENV_ROOT="$HOME/.pyenv"'
-append_once '[[ -d "$PYENV_ROOT/bin" ]] && export PATH="$PYENV_ROOT/bin:$PATH"'
-append_once '[[ -d "$PYENV_ROOT/shims" ]] && export PATH="$PYENV_ROOT/shims:$PATH"'
-append_once '[[ -d "$HOME/.atuin/bin" ]] && export PATH="$HOME/.atuin/bin:$PATH"'
-append_once 'command -v pyenv >/dev/null 2>&1 && eval "$(pyenv init -)"'
-append_once 'alias ll="ls -lah"'
-append_once 'alias vim="nvim"'
-append_once 'alias vi="nvim"'
-append_once 'alias fm="yazi"'
-append_once 'eval "$(direnv hook zsh)"'
-append_once 'if [ -x "$HOME/.atuin/bin/atuin" ]; then eval "$($HOME/.atuin/bin/atuin init zsh)"; elif command -v atuin >/dev/null 2>&1; then eval "$(atuin init zsh)"; fi'
-append_once '[ -f "$(npm root -g 2>/dev/null)/spaceship-prompt/spaceship.zsh" ] && source "$(npm root -g)/spaceship-prompt/spaceship.zsh"'
-chown "$TARGET_USER:$TARGET_USER" "$ZSHRC" || true
-
-if command -v zsh >/dev/null 2>&1; then
-  chsh -s "$(command -v zsh)" "$TARGET_USER" || true
-fi
-"""
+    def _sensitive_cleanup_script(self) -> str:
+        return self.render_template("cleanup-sensitive-state.sh.tmpl", {})
 
     def setup(self, conn) -> None:
         self.exec.fs_create_dir(conn, self.target_path)
@@ -259,6 +58,15 @@ fi
         self.state = "running"
 
     def teardown(self, conn) -> None:
+        cleanup_path = f"{self.target_path}/cleanup-sensitive-state.sh"
+        self.exec.fs_write_file(conn, cleanup_path, self._sensitive_cleanup_script())
+        quoted_cleanup_path = shlex.quote(cleanup_path)
+        self.exec.execute(
+            conn, f"chmod +x {quoted_cleanup_path}", group=TaskGroup.FILESYSTEM
+        )
+        self.exec.execute(
+            conn, quoted_cleanup_path, group=TaskGroup.SECURITY_ASSETS, sudo=True
+        )
         self.exec.fs_delete_dir(conn, self.target_path)
         self.state = "un-initialized"
 
@@ -271,7 +79,7 @@ fi
         return True
 
     def check(self, conn) -> Dict[str, str]:
-        command = """command -v zsh git nvim mc yazi atuin claude pyenv >/dev/null
+        command = """command -v zsh git nvim mc yazi atuin claude pyenv tmux >/dev/null
 nvim_version="$(nvim --version | sed -n '1s/^NVIM v//p' | cut -d- -f1)"
 [ -n "$nvim_version" ] && dpkg --compare-versions "$nvim_version" ge 0.11.2"""
         try:

--- a/mlox/services/k8s_headlamp/cluster-admin-binding.yaml.tmpl
+++ b/mlox/services/k8s_headlamp/cluster-admin-binding.yaml.tmpl
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: @binding_name
+subjects:
+  - kind: ServiceAccount
+    name: @service_name
+    namespace: @namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/mlox/services/k8s_headlamp/gadgets-values.yaml.tmpl
+++ b/mlox/services/k8s_headlamp/gadgets-values.yaml.tmpl
@@ -1,0 +1,31 @@
+initContainers:
+  - name: headlamp-plugins
+    image: ghcr.io/inspektor-gadget/headlamp-plugin:0.1.0-beta.2
+    imagePullPolicy: Always
+    command:
+      [
+        "/bin/sh",
+        "-c",
+        "mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/",
+      ]
+    volumeMounts:
+      - name: headlamp-plugins
+        mountPath: /build/plugins
+
+persistentVolumeClaim:
+  enabled: true
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi
+
+volumeMounts:
+  - name: headlamp-plugins
+    mountPath: /build/plugins
+
+volumes:
+  - name: headlamp-plugins
+    persistentVolumeClaim:
+      claimName: "@service_name"
+
+config:
+  pluginsDir: /build/plugins

--- a/mlox/services/k8s_headlamp/ingress.yaml.tmpl
+++ b/mlox/services/k8s_headlamp/ingress.yaml.tmpl
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: @ingress_name
+  namespace: @namespace
+  annotations:
+@annotations_block
+spec:
+  ingressClassName: traefik
+  rules:
+  - http:
+      paths:
+      - path: @path
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: @service_name
+            port:
+              number: @backend_port

--- a/mlox/services/k8s_headlamp/k8s.py
+++ b/mlox/services/k8s_headlamp/k8s.py
@@ -127,47 +127,28 @@ class K8sHeadlampService(AbstractService):
             )
         annotations_block = "\n".join(annotations_lines)
 
-        ingress_manifest = f"""apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {ingress_name}
-  namespace: {self.namespace}
-  annotations:
-{annotations_block}
-spec:
-  ingressClassName: traefik
-  rules:
-  - http:
-      paths:
-      - path: {path}
-        pathType: ImplementationSpecific
-        backend:
-          service:
-            name: {self.service_name}
-            port:
-              number: {backend_port}
-"""
-        middleware_manifest = ""
+        template_vars = {
+            "ingress_name": ingress_name,
+            "namespace": self.namespace,
+            "annotations_block": annotations_block,
+            "path": path,
+            "service_name": self.service_name,
+            "backend_port": backend_port,
+        }
+        manifest = self.render_template("ingress.yaml.tmpl", template_vars)
         if middleware_name:
-            middleware_manifest = f"""---
-apiVersion: traefik.containo.us/v1alpha1
-kind: Middleware
-metadata:
-  name: {middleware_name}
-  namespace: {self.namespace}
-spec:
-  stripPrefix:
-    prefixes:
-    - {path}
-"""
+            manifest += self.render_template(
+                "middleware.yaml.tmpl",
+                {
+                    "middleware_name": middleware_name,
+                    "namespace": self.namespace,
+                    "path": path,
+                },
+            )
 
         manifest_path = f"{self.target_path}/{ingress_name}.yaml"
         self.exec.fs_create_dir(conn, self.target_path)
-        self.exec.fs_write_file(
-            conn,
-            manifest_path,
-            f"{ingress_manifest}{middleware_manifest}",
-        )
+        self.exec.fs_write_file(conn, manifest_path, manifest)
         self.exec.k8s_apply_manifest(
             conn,
             manifest_path,
@@ -184,40 +165,13 @@ spec:
         logger.info("🔧 Enabling Headlamp Gadgets plugin")
         values_path = f"{self.target_path}/plugin-gadgets-values.yaml"
 
-        values_yaml = f"""initContainers:
-  - name: headlamp-plugins
-    image: ghcr.io/inspektor-gadget/headlamp-plugin:0.1.0-beta.2
-    imagePullPolicy: Always
-    command:
-      [
-        "/bin/sh",
-        "-c",
-        "mkdir -p /build/plugins && cp -r /plugins/* /build/plugins/",
-      ]
-    volumeMounts:
-      - name: headlamp-plugins
-        mountPath: /build/plugins
-
-persistentVolumeClaim:
-  enabled: true
-  accessModes:
-    - ReadWriteOnce
-  size: 1Gi
-
-volumeMounts:
-  - name: headlamp-plugins
-    mountPath: /build/plugins
-
-volumes:
-  - name: headlamp-plugins
-    persistentVolumeClaim:
-      claimName: "{self.service_name}"
-
-config:
-  pluginsDir: /build/plugins
-"""
         self.exec.fs_create_dir(conn, self.target_path)
-        self.exec.fs_write_file(conn, values_path, values_yaml)
+        self.render_template_to_file(
+            conn,
+            "gadgets-values.yaml.tmpl",
+            values_path,
+            {"service_name": self.service_name},
+        )
 
         # Upgrade the existing release with the plugin values.
         self.exec.helm_upgrade_install(
@@ -235,21 +189,17 @@ config:
         """Grant Headlamp service account cluster-admin to enable log access."""
         binding_name = f"{self.service_name}-cluster-admin"
         manifest_path = f"{self.target_path}/{binding_name}.yaml"
-        manifest = f"""apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {binding_name}
-subjects:
-  - kind: ServiceAccount
-    name: {self.service_name}
-    namespace: {self.namespace}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-"""
         self.exec.fs_create_dir(conn, self.target_path)
-        self.exec.fs_write_file(conn, manifest_path, manifest)
+        self.render_template_to_file(
+            conn,
+            "cluster-admin-binding.yaml.tmpl",
+            manifest_path,
+            {
+                "binding_name": binding_name,
+                "service_name": self.service_name,
+                "namespace": self.namespace,
+            },
+        )
         self.exec.k8s_apply_manifest(
             conn,
             manifest_path,

--- a/mlox/services/k8s_headlamp/middleware.yaml.tmpl
+++ b/mlox/services/k8s_headlamp/middleware.yaml.tmpl
@@ -1,0 +1,10 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: @middleware_name
+  namespace: @namespace
+spec:
+  stripPrefix:
+    prefixes:
+    - @path

--- a/mlox/services/kubeapps/admin-binding.yaml.tmpl
+++ b/mlox/services/kubeapps/admin-binding.yaml.tmpl
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: @service_account_name
+  namespace: @namespace
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: @binding_name
+subjects:
+  - kind: ServiceAccount
+    name: @service_account_name
+    namespace: @namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/mlox/services/kubeapps/ingress.yaml.tmpl
+++ b/mlox/services/kubeapps/ingress.yaml.tmpl
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: @ingress_name
+  namespace: @namespace
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: @entrypoint
+    traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+@host_line
+        paths:
+          - path: @path
+            pathType: Prefix
+            backend:
+              service:
+                name: @release_name
+                port:
+                  number: @backend_service_port
+  tls:
+    - hosts:@tls_hosts
+      secretName: @tls_secret_name

--- a/mlox/services/kubeapps/k8s.py
+++ b/mlox/services/kubeapps/k8s.py
@@ -94,34 +94,24 @@ class KubeAppsService(AbstractService):
         host_line = f"    - host: {host}\n      http:" if host else "    - http:"
         tls_hosts = f"\n        - {host}" if host else " []"
 
-        ingress_manifest = f"""apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {ingress_name}
-  namespace: {self.namespace}
-  annotations:
-    kubernetes.io/ingress.class: traefik
-    traefik.ingress.kubernetes.io/router.entrypoints: {entrypoint}
-    traefik.ingress.kubernetes.io/router.tls: "true"
-spec:
-  ingressClassName: traefik
-  rules:
-{host_line}
-        paths:
-          - path: {path}
-            pathType: Prefix
-            backend:
-              service:
-                name: {self.release_name}
-                port:
-                  number: {backend_service_port}
-  tls:
-    - hosts:{tls_hosts}
-      secretName: {tls_secret_name}
-"""
         manifest_path = f"{self.target_path}/{ingress_name}.yaml"
         self.exec.fs_create_dir(conn, self.target_path)
-        self.exec.fs_write_file(conn, manifest_path, ingress_manifest)
+        self.render_template_to_file(
+            conn,
+            "ingress.yaml.tmpl",
+            manifest_path,
+            {
+                "ingress_name": ingress_name,
+                "namespace": self.namespace,
+                "entrypoint": entrypoint,
+                "host_line": host_line,
+                "path": path,
+                "release_name": self.release_name,
+                "backend_service_port": backend_service_port,
+                "tls_hosts": tls_hosts,
+                "tls_secret_name": tls_secret_name,
+            },
+        )
         self.exec.k8s_apply_manifest(
             conn,
             manifest_path,
@@ -311,27 +301,17 @@ spec:
     def _bind_service_account_cluster_admin(self, conn) -> None:
         binding_name = self._cluster_role_binding_name()
         manifest_path = f"{self.target_path}/{binding_name}.yaml"
-        manifest = f"""apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {self.service_account_name}
-  namespace: {self.namespace}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {binding_name}
-subjects:
-  - kind: ServiceAccount
-    name: {self.service_account_name}
-    namespace: {self.namespace}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-"""
         self.exec.fs_create_dir(conn, self.target_path)
-        self.exec.fs_write_file(conn, manifest_path, manifest)
+        self.render_template_to_file(
+            conn,
+            "admin-binding.yaml.tmpl",
+            manifest_path,
+            {
+                "service_account_name": self.service_account_name,
+                "namespace": self.namespace,
+                "binding_name": binding_name,
+            },
+        )
         self.exec.k8s_apply_manifest(
             conn,
             manifest_path,

--- a/mlox/services/kubeflow/k8s.py
+++ b/mlox/services/kubeflow/k8s.py
@@ -408,44 +408,16 @@ class KubeflowService(AbstractService):
 
     def _write_traefik_values(self, conn) -> str:
         values_path = f"{self.target_path}/kubeflow-traefik-values.yaml"
-        values = f"""ingressClass:
-  enabled: false
-gateway:
-  enabled: false
-providers:
-  kubernetesCRD:
-    enabled: false
-  kubernetesIngress:
-    enabled: false
-  file:
-    enabled: true
-    content: |-
-      http:
-        routers:
-          kubeflow:
-            entryPoints:
-              - websecure
-            rule: PathPrefix(`/`)
-            service: kubeflow
-            tls: {{}}
-        services:
-          kubeflow:
-            loadBalancer:
-              servers:
-                - url: http://{self.ingress_service}.{self.ingress_namespace}.svc.cluster.local:80
-ports:
-  web:
-    expose:
-      default: false
-  websecure:
-    port: {self.ingress_port}
-    exposedPort: {self.ingress_port}
-    expose:
-      default: true
-service:
-  type: LoadBalancer
-"""
-        self.exec.fs_write_file(conn, values_path, values)
+        self.render_template_to_file(
+            conn,
+            "kubeflow-traefik-values.yaml.tmpl",
+            values_path,
+            {
+                "ingress_service": self.ingress_service,
+                "ingress_namespace": self.ingress_namespace,
+                "ingress_port": self.ingress_port,
+            },
+        )
         return values_path
 
     def _install_dedicated_traefik(self, conn, values_path: str) -> bool:

--- a/mlox/services/kubeflow/kubeflow-traefik-values.yaml.tmpl
+++ b/mlox/services/kubeflow/kubeflow-traefik-values.yaml.tmpl
@@ -1,0 +1,36 @@
+ingressClass:
+  enabled: false
+gateway:
+  enabled: false
+providers:
+  kubernetesCRD:
+    enabled: false
+  kubernetesIngress:
+    enabled: false
+  file:
+    enabled: true
+    content: |-
+      http:
+        routers:
+          kubeflow:
+            entryPoints:
+              - websecure
+            rule: PathPrefix(`/`)
+            service: kubeflow
+            tls: {}
+        services:
+          kubeflow:
+            loadBalancer:
+              servers:
+                - url: http://@ingress_service.@ingress_namespace.svc.cluster.local:80
+ports:
+  web:
+    expose:
+      default: false
+  websecure:
+    port: @ingress_port
+    exposedPort: @ingress_port
+    expose:
+      default: true
+service:
+  type: LoadBalancer

--- a/mlox/services/mlflow_gateway/gateway-manifest.yaml.tmpl
+++ b/mlox/services/mlflow_gateway/gateway-manifest.yaml.tmpl
@@ -1,0 +1,139 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: @namespace
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlflow-gateway-code
+  namespace: @namespace
+data:
+  serve.py: |-
+@serve_script_block
+  gateway-requirements.txt: |-
+@requirements_block
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlflow-gateway-credentials
+  namespace: @namespace
+type: Opaque
+stringData:
+  gateway-user: @gateway_user
+  gateway-password: @gateway_password
+  tracking-uri: @tracking_uri
+  tracking-user: @tracking_user
+  tracking-password: @tracking_password
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: @deployment_name
+  namespace: @namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mlflow-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mlflow-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: python:3.12-slim
+          imagePullPolicy: IfNotPresent
+          workingDir: /app
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              pip install --no-cache-dir \
+                "mlflow==3.8.1" \
+                "mlflow[extras]==3.8.1" \
+                "fastapi==0.115.0" \
+                "uvicorn[standard]==0.30.6" \
+                "pandas>=2.2" \
+                "numpy>=1.26"
+              if [ -s /app/gateway-requirements.txt ]; then
+                pip install --no-cache-dir -r /app/gateway-requirements.txt
+              fi
+              exec uvicorn serve:app --host 0.0.0.0 --port @container_port
+          env:
+            - name: MLFLOW_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-uri
+            - name: MLFLOW_TRACKING_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-uri
+            - name: MLFLOW_TRACKING_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-user
+            - name: MLFLOW_TRACKING_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-password
+            - name: MLFLOW_TRACKING_INSECURE_TLS
+              value: "true"
+            - name: MLOX_GATEWAY_CACHE_MAX_MODELS
+              value: @cache_size
+            - name: MLOX_GATEWAY_CACHE_TTL_DAYS
+              value: @cache_ttl
+          ports:
+            - name: http
+              containerPort: @container_port
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 6
+          volumeMounts:
+            - name: gateway-code
+              mountPath: /app/serve.py
+              subPath: serve.py
+              readOnly: true
+            - name: gateway-code
+              mountPath: /app/gateway-requirements.txt
+              subPath: gateway-requirements.txt
+              readOnly: true
+      volumes:
+        - name: gateway-code
+          configMap:
+            name: mlflow-gateway-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: @service_name
+  namespace: @namespace
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mlflow-gateway
+  ports:
+    - name: http
+      port: @container_port
+      targetPort: http

--- a/mlox/services/mlflow_gateway/k3s.py
+++ b/mlox/services/mlflow_gateway/k3s.py
@@ -1,7 +1,5 @@
-import json
 import logging
 import shlex
-import textwrap
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -37,214 +35,47 @@ class MLFlowGatewayK3sService(MLFlowGatewayDockerService):
         self.manifest_path = f"{self.target_path}/mlflow-gateway.yaml"
         self.traefik_values_path = f"{self.target_path}/traefik-values.yaml"
 
-    @staticmethod
-    def _yaml_string(value: str) -> str:
-        return json.dumps(value)
-
-    @staticmethod
-    def _config_map_block(value: str) -> str:
-        return textwrap.indent(value.rstrip(), "    ")
-
     def _render_gateway_manifest(self) -> str:
         serve_script = Path(self.serve_script).read_text(encoding="utf-8")
         requirements = _resolved_text(self.requirements_txt)
         cache_size = _resolved_setting(self.cache_max_models, "10")
         cache_ttl = _resolved_setting(self.cache_ttl_days, "10")
 
-        return f"""apiVersion: v1
-kind: Namespace
-metadata:
-  name: {self.namespace}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mlflow-gateway-code
-  namespace: {self.namespace}
-data:
-  serve.py: |-
-{self._config_map_block(serve_script)}
-  gateway-requirements.txt: |-
-{self._config_map_block(requirements)}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mlflow-gateway-credentials
-  namespace: {self.namespace}
-type: Opaque
-stringData:
-  gateway-user: {self._yaml_string(self.user)}
-  gateway-password: {self._yaml_string(self.pw)}
-  tracking-uri: {self._yaml_string(self.tracking_uri)}
-  tracking-user: {self._yaml_string(self.tracking_user)}
-  tracking-password: {self._yaml_string(self.tracking_pw)}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {self.deployment_name}
-  namespace: {self.namespace}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: mlflow-gateway
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: mlflow-gateway
-    spec:
-      containers:
-        - name: gateway
-          image: python:3.12-slim
-          imagePullPolicy: IfNotPresent
-          workingDir: /app
-          command: ["/bin/bash", "-lc"]
-          args:
-            - |
-              set -euo pipefail
-              pip install --no-cache-dir \
-                "mlflow==3.8.1" \
-                "mlflow[extras]==3.8.1" \
-                "fastapi==0.115.0" \
-                "uvicorn[standard]==0.30.6" \
-                "pandas>=2.2" \
-                "numpy>=1.26"
-              if [ -s /app/gateway-requirements.txt ]; then
-                pip install --no-cache-dir -r /app/gateway-requirements.txt
-              fi
-              exec uvicorn serve:app --host 0.0.0.0 --port {self.container_port}
-          env:
-            - name: MLFLOW_URI
-              valueFrom:
-                secretKeyRef:
-                  name: mlflow-gateway-credentials
-                  key: tracking-uri
-            - name: MLFLOW_TRACKING_URI
-              valueFrom:
-                secretKeyRef:
-                  name: mlflow-gateway-credentials
-                  key: tracking-uri
-            - name: MLFLOW_TRACKING_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: mlflow-gateway-credentials
-                  key: tracking-user
-            - name: MLFLOW_TRACKING_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: mlflow-gateway-credentials
-                  key: tracking-password
-            - name: MLFLOW_TRACKING_INSECURE_TLS
-              value: "true"
-            - name: MLOX_GATEWAY_CACHE_MAX_MODELS
-              value: {self._yaml_string(cache_size)}
-            - name: MLOX_GATEWAY_CACHE_TTL_DAYS
-              value: {self._yaml_string(cache_ttl)}
-          ports:
-            - name: http
-              containerPort: {self.container_port}
-          startupProbe:
-            httpGet:
-              path: /health
-              port: http
-            periodSeconds: 5
-            failureThreshold: 120
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            periodSeconds: 5
-            failureThreshold: 6
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            periodSeconds: 10
-            failureThreshold: 6
-          volumeMounts:
-            - name: gateway-code
-              mountPath: /app/serve.py
-              subPath: serve.py
-              readOnly: true
-            - name: gateway-code
-              mountPath: /app/gateway-requirements.txt
-              subPath: gateway-requirements.txt
-              readOnly: true
-      volumes:
-        - name: gateway-code
-          configMap:
-            name: mlflow-gateway-code
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {self.service_name}
-  namespace: {self.namespace}
-spec:
-  type: ClusterIP
-  selector:
-    app.kubernetes.io/name: mlflow-gateway
-  ports:
-    - name: http
-      port: {self.container_port}
-      targetPort: http
-"""
+        return self.render_template(
+            "gateway-manifest.yaml.tmpl",
+            {
+                "namespace": self.namespace,
+                "serve_script_block": self.indent_block(serve_script, 4),
+                "requirements_block": self.indent_block(requirements, 4),
+                "gateway_user": self.yaml_scalar(self.user),
+                "gateway_password": self.yaml_scalar(self.pw),
+                "tracking_uri": self.yaml_scalar(self.tracking_uri),
+                "tracking_user": self.yaml_scalar(self.tracking_user),
+                "tracking_password": self.yaml_scalar(self.tracking_pw),
+                "deployment_name": self.deployment_name,
+                "container_port": self.container_port,
+                "cache_size": self.yaml_scalar(cache_size),
+                "cache_ttl": self.yaml_scalar(cache_ttl),
+                "service_name": self.service_name,
+            },
+        )
 
     def _render_traefik_values(self) -> str:
         password_hash = apr_md5_crypt.hash(self.pw)
-        auth_user = self._yaml_string(f"{self.user}:{password_hash}")
+        auth_user = self.yaml_scalar(f"{self.user}:{password_hash}")
         backend_url = (
             f"http://{self.service_name}.{self.namespace}.svc.cluster.local:"
             f"{self.container_port}"
         )
 
-        return f"""deployment:
-  replicas: 1
-ingressClass:
-  enabled: false
-providers:
-  kubernetesCRD:
-    enabled: false
-  kubernetesIngress:
-    enabled: false
-  file:
-    enabled: true
-    watch: true
-    content: |-
-      http:
-        routers:
-          gateway:
-            entryPoints:
-              - websecure
-            rule: PathPrefix(`/`)
-            service: gateway
-            middlewares:
-              - gateway-auth
-            tls: {{}}
-        middlewares:
-          gateway-auth:
-            basicAuth:
-              users:
-                - {auth_user}
-        services:
-          gateway:
-            loadBalancer:
-              servers:
-                - url: {self._yaml_string(backend_url)}
-ports:
-  web:
-    expose:
-      default: false
-  websecure:
-    port: 8443
-    exposedPort: {self.port}
-    expose:
-      default: true
-service:
-  type: LoadBalancer
-"""
+        return self.render_template(
+            "traefik-values.yaml.tmpl",
+            {
+                "auth_user": auth_user,
+                "backend_url": self.yaml_scalar(backend_url),
+                "port": self.port,
+            },
+        )
 
     def _kubectl(self, arguments: str) -> str:
         return f"kubectl --kubeconfig {shlex.quote(self.kubeconfig)} {arguments}"

--- a/mlox/services/mlflow_gateway/traefik-values.yaml.tmpl
+++ b/mlox/services/mlflow_gateway/traefik-values.yaml.tmpl
@@ -1,0 +1,44 @@
+deployment:
+  replicas: 1
+ingressClass:
+  enabled: false
+providers:
+  kubernetesCRD:
+    enabled: false
+  kubernetesIngress:
+    enabled: false
+  file:
+    enabled: true
+    watch: true
+    content: |-
+      http:
+        routers:
+          gateway:
+            entryPoints:
+              - websecure
+            rule: PathPrefix(`/`)
+            service: gateway
+            middlewares:
+              - gateway-auth
+            tls: {}
+        middlewares:
+          gateway-auth:
+            basicAuth:
+              users:
+                - @auth_user
+        services:
+          gateway:
+            loadBalancer:
+              servers:
+                - url: @backend_url
+ports:
+  web:
+    expose:
+      default: false
+  websecure:
+    port: 8443
+    exposedPort: @port
+    expose:
+      default: true
+service:
+  type: LoadBalancer

--- a/mlox/services/mlflow_mlserver/k3s.py
+++ b/mlox/services/mlflow_mlserver/k3s.py
@@ -48,76 +48,21 @@ class MLFlowMLServerK3sService(MLFlowMLServerDockerService):
             """
         ).strip()
 
-        return f"""apiVersion: v1
-kind: Namespace
-metadata:
-  name: {self.namespace}
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {self.deployment_name}
-  namespace: {self.namespace}
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: {self.service_name}
-  template:
-    metadata:
-      labels:
-        app: {self.service_name}
-    spec:
-      containers:
-      - name: mlserver
-        image: python:3.11-slim
-        imagePullPolicy: IfNotPresent
-        command: ["/bin/bash", "-lc"]
-        args:
-        - |
-{textwrap.indent(startup_cmd, '          ')}
-        ports:
-        - containerPort: {self.container_port}
-          name: http
-        env:
-        - name: MLFLOW_TRACKING_URI
-          value: '{tracking_uri}'
-        - name: MLFLOW_TRACKING_USERNAME
-          value: '{tracking_user}'
-        - name: MLFLOW_TRACKING_PASSWORD
-          value: '{tracking_pw}'
-        - name: MLFLOW_TRACKING_INSECURE_TLS
-          value: "true"
-        - name: MLFLOW_REMOTE_MODEL
-          value: '{model}'
-        readinessProbe:
-          httpGet:
-            path: /v2/health/ready
-            port: {self.container_port}
-          initialDelaySeconds: 20
-          periodSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /v2/health/live
-            port: {self.container_port}
-          initialDelaySeconds: 40
-          periodSeconds: 10
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {self.service_name}
-  namespace: {self.namespace}
-spec:
-  type: NodePort
-  selector:
-    app: {self.service_name}
-  ports:
-  - name: http
-    port: {self.container_port}
-    targetPort: {self.container_port}
-    nodePort: {self.port}
-"""
+        return self.render_template(
+            "mlserver-manifest.yaml.tmpl",
+            {
+                "namespace": self.namespace,
+                "deployment_name": self.deployment_name,
+                "service_name": self.service_name,
+                "startup_cmd_block": self.indent_block(startup_cmd, 10),
+                "container_port": self.container_port,
+                "tracking_uri": tracking_uri,
+                "tracking_user": tracking_user,
+                "tracking_pw": tracking_pw,
+                "model": model,
+                "port": self.port,
+            },
+        )
 
     def setup(self, conn) -> None:
         self.exec.fs_create_dir(conn, self.target_path)

--- a/mlox/services/mlflow_mlserver/mlserver-manifest.yaml.tmpl
+++ b/mlox/services/mlflow_mlserver/mlserver-manifest.yaml.tmpl
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: @namespace
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: @deployment_name
+  namespace: @namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: @service_name
+  template:
+    metadata:
+      labels:
+        app: @service_name
+    spec:
+      containers:
+      - name: mlserver
+        image: python:3.11-slim
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash", "-lc"]
+        args:
+        - |
+@startup_cmd_block
+        ports:
+        - containerPort: @container_port
+          name: http
+        env:
+        - name: MLFLOW_TRACKING_URI
+          value: '@tracking_uri'
+        - name: MLFLOW_TRACKING_USERNAME
+          value: '@tracking_user'
+        - name: MLFLOW_TRACKING_PASSWORD
+          value: '@tracking_pw'
+        - name: MLFLOW_TRACKING_INSECURE_TLS
+          value: "true"
+        - name: MLFLOW_REMOTE_MODEL
+          value: '@model'
+        readinessProbe:
+          httpGet:
+            path: /v2/health/ready
+            port: @container_port
+          initialDelaySeconds: 20
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /v2/health/live
+            port: @container_port
+          initialDelaySeconds: 40
+          periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: @service_name
+  namespace: @namespace
+spec:
+  type: NodePort
+  selector:
+    app: @service_name
+  ports:
+  - name: http
+    port: @container_port
+    targetPort: @container_port
+    nodePort: @port

--- a/mlox/tui/screens/dashboard/tree.py
+++ b/mlox/tui/screens/dashboard/tree.py
@@ -36,7 +36,7 @@ class InfraTree(Tree[SelectionInfo]):
 
         infra = getattr(workspace, "infrastructure", None)
         if not infra or not infra.bundles:
-            self.root.add(
+            self.root.add_leaf(
                 "No infrastructure available", data=SelectionInfo(type="empty")
             )
             self.root.expand()
@@ -54,15 +54,15 @@ class InfraTree(Tree[SelectionInfo]):
                 if server
                 else "Server: unknown"
             )
-            bundle_node.add(
+            bundle_node.add_leaf(
                 server_label,
                 data=SelectionInfo(type="server", bundle=bundle, server=server),
             )
             if not bundle.services:
-                bundle_node.add("No services", data=SelectionInfo(type="empty"))
+                bundle_node.add_leaf("No services", data=SelectionInfo(type="empty"))
                 continue
             for svc in bundle.services:
-                bundle_node.add(
+                bundle_node.add_leaf(
                     f"Service: {svc.name}",
                     data=SelectionInfo(
                         type="service", bundle=bundle, server=server, service=svc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,5 +137,9 @@ dev_template = "{tag}.post{ccount}"
 
 [tool.setuptools]
 include-package-data = true
+
+[tool.setuptools.package-data]
+mlox = ["services/**/*.tmpl"]
+
 [tool.setuptools.packages.find]
 include = ["mlox*"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,6 +9,8 @@ addopts = -q -rfExs -s
 markers =
     integration: marks tests as integration tests (heavy / hardware / external dependencies)
     unit: marks unit tests
+    kubernetes: marks tests that require a Kubernetes backend
+    slow: marks slow tests
 
 # Enable live logging to show fixture output and debug information during test runs
 log_cli = true

--- a/taskfile.dist.yml
+++ b/taskfile.dist.yml
@@ -14,6 +14,7 @@ vars:
     - deps:lock:all|dev|gcp : compile extras to requirements-<extra>.txt
     - deps:install:tools    : install tools like Multipass for integration tests
     - tests:integration:run     : run integration tests (requires Multipass)
+    - tests:integration:k8s     : run Kubernetes integration tests (requires Multipass/k3s)
     - tests:integration:cleanup : clean up test Multipass VMs
     - docker:build        : build local Docker image
     - project:new         : create an encrypted .mlox project
@@ -152,6 +153,25 @@ tasks:
           exit 1; \
         fi
       - '{{.PYTHON | default "python"}} -m pytest -m integration --run-integration'
+
+  tests:integration:k8s:
+    aliases: [tests:integration:kubernetes]
+    silent: true
+    desc: Run Kubernetes integration tests (requires Multipass/k3s)
+    cmds:
+      - |
+        if ! command -v multipass >/dev/null 2>&1; then \
+          printf '\n\033[1;31m✖ Multipass is not installed.\033[0m\n'; \
+          printf 'Install it first. Run: \033[1mtask deps:install:tools\033[0m\n\n'; \
+          exit 1; \
+        fi
+      - |
+        if ! {{.PYTHON | default "python"}} -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('pytest') else 1)"; then \
+          printf '\n\033[1;31m✖ pytest not installed.\033[0m\n'; \
+          printf 'Install dev deps, e.g.: \033[1m{{.PYTHON | default "python"}} -m pip install -e .[dev]\033[0m\n\n'; \
+          exit 1; \
+        fi
+      - '{{.PYTHON | default "python"}} -m pytest tests/integration -m "integration and kubernetes" --run-integration'
 
   tests:integration:service:
     silent: true

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -160,14 +160,21 @@ def wait_for_service_ready(
     return status
 
 
-def wait_for_k3s_ready(server, timeout: int = 180, interval: float = 5.0) -> None:
-    """Wait until the k3s node is Ready on a provisioned Kubernetes server."""
+def wait_for_k3s_ready(
+    server, timeout: int = 300, interval: float = 5.0, force_root: bool = False
+) -> None:
+    """Wait until the k3s node is Ready on a provisioned Kubernetes server.
+
+    This runs after ``server.setup()``, which creates the normal MLOX SSH user
+    and disables password-based access. Use the default post-setup credentials
+    instead of forcing the initial root/password login path.
+    """
 
     deadline = time.time() + timeout
     last_output = ""
     while time.time() < deadline:
         try:
-            with server.get_server_connection(force_root=True) as conn:
+            with server.get_server_connection(force_root=force_root) as conn:
                 nodes = server.exec.execute(
                     conn,
                     "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes --no-headers",
@@ -328,6 +335,7 @@ def ubuntu_k3s_server(multipass_k8s_instance):
     server = bundle.server
     wait_for_server_login(server, timeout=240, interval=5.0, force_root=True)
     server.setup()
+    wait_for_server_login(server, timeout=240, interval=5.0, force_root=False)
     wait_for_k3s_ready(server)
     yield server
     logging.info(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,7 +32,13 @@ pytestmark = pytest.mark.integration
 def wait_for_ssh(
     vm: MultipassVM, vm_name: str, timeout: int = 120, interval: float = 2.0
 ) -> str:
-    """Wait until the VM has an IPv4 and port 22 is reachable. Returns the ip when ready."""
+    """Wait until the VM has an IPv4 and port 22 is reachable. Returns the ip when ready.
+
+    This only proves that sshd is listening on TCP/22. Multipass guests can
+    briefly accept TCP connections before the SSH daemon is ready to complete a
+    protocol handshake, so fixtures should also call ``wait_for_server_login``
+    before running Fabric/MLOX setup commands.
+    """
     deadline = time.time() + timeout
     last_exc = None
     while time.time() < deadline:
@@ -67,6 +73,33 @@ def wait_for_ssh(
         time.sleep(interval)
     raise TimeoutError(
         f"VM {vm_name} SSH not reachable after {timeout}s. Last error: {last_exc!r}"
+    )
+
+
+def wait_for_server_login(
+    server, timeout: int = 180, interval: float = 3.0, force_root: bool = True
+) -> None:
+    """Wait until Fabric can complete an SSH login and run a no-op command."""
+
+    deadline = time.time() + timeout
+    last_exc: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with server.get_server_connection(force_root=force_root) as conn:
+                conn.run("true", hide=True, warn=False, pty=False)
+            return
+        except Exception as exc:  # pragma: no cover - remote environment dependent
+            last_exc = exc
+            logging.warning(
+                "Waiting for stable SSH login to %s after %s: %s",
+                getattr(server, "ip", "?"),
+                type(exc).__name__,
+                exc,
+            )
+            time.sleep(interval)
+    raise TimeoutError(
+        f"Server SSH login did not become ready after {timeout}s. "
+        f"Last error: {last_exc!r}"
     )
 
 
@@ -293,6 +326,7 @@ def ubuntu_k3s_server(multipass_k8s_instance):
     if not bundle:
         pytest.fail("Failed to add k3s server to infrastructure")
     server = bundle.server
+    wait_for_server_login(server, timeout=240, interval=5.0, force_root=True)
     server.setup()
     wait_for_k3s_ready(server)
     yield server

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,7 @@ from typing import Callable, Dict, Optional
 
 from mlox.config import load_config, get_stacks_path
 from mlox.infra import Infrastructure
+from mlox.executors import TaskGroup
 
 logger = logging.getLogger(__name__)
 try:
@@ -126,6 +127,37 @@ def wait_for_service_ready(
     return status
 
 
+def wait_for_k3s_ready(server, timeout: int = 180, interval: float = 5.0) -> None:
+    """Wait until the k3s node is Ready on a provisioned Kubernetes server."""
+
+    deadline = time.time() + timeout
+    last_output = ""
+    while time.time() < deadline:
+        try:
+            with server.get_server_connection(force_root=True) as conn:
+                nodes = server.exec.execute(
+                    conn,
+                    "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes --no-headers",
+                    group=TaskGroup.KUBERNETES,
+                    sudo=True,
+                    pty=False,
+                )
+                pods = server.exec.execute(
+                    conn,
+                    "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get pods -A --no-headers",
+                    group=TaskGroup.KUBERNETES,
+                    sudo=True,
+                    pty=False,
+                )
+            last_output = f"nodes={nodes!r} pods={pods!r}"
+            if nodes and " Ready " in f" {nodes} ":
+                return
+        except Exception as exc:  # pragma: no cover - remote environment dependent
+            last_output = repr(exc)
+        time.sleep(interval)
+    raise TimeoutError(f"k3s did not become ready after {timeout}s: {last_output}")
+
+
 @pytest.fixture(scope="package")
 def multipass_instance():
     if not _HAS_MULTIPASS:
@@ -206,6 +238,72 @@ def ubuntu_docker_server(multipass_instance):
         logging.info("Successfully tore down ubuntu_docker_server.")
     except Exception as e:
         logging.warning(f"Could not tear down ubuntu_docker_server: {e}")
+    infra.remove_bundle(bundle)
+
+
+@pytest.fixture(scope="package")
+def multipass_k8s_instance():
+    if not _HAS_MULTIPASS:
+        pytest.skip(
+            "multipass package not available; skip integration tests that require Multipass"
+        )
+
+    client = MultipassClient()
+    name = f"mlox-k8s-test-{uuid.uuid4().hex[:8]}"
+    cloud_init_path = (
+        Path(__file__).resolve().parents[2] / "mlox/assets/cloud-init.yaml"
+    )
+    logging.info(
+        f"Launching Kubernetes Multipass VM {name} with cloud-init {cloud_init_path}"
+    )
+    vm = client.launch(
+        vm_name=name, cpu=4, disk="60G", mem="12G", cloud_init=cloud_init_path
+    )
+    ip = wait_for_ssh(vm, name, timeout=180, interval=3.0)
+    vm.info()
+    logging.info(f"Kubernetes Multipass VM {name} is running at IP {ip}")
+    yield {"client": client, "vm": vm, "name": name, "ip": ip}
+    logging.info(f"Cleaning up Kubernetes Multipass VM {name}...")
+    try:
+        vm.delete()
+        client.purge()
+        logging.info(f"Successfully cleaned up Kubernetes Multipass VM {name}.")
+    except Exception as e:
+        logging.warning(f"Could not clean up Kubernetes Multipass VM {name}: {e}")
+
+
+@pytest.fixture(scope="package")
+def ubuntu_k3s_server(multipass_k8s_instance):
+    infra = Infrastructure()
+    config = load_config(
+        get_stacks_path(prefix="mlox-server"),
+        "/ubuntu",
+        "mlox-server.ubuntu.k3s.yaml",
+    )
+    params = {
+        "${MLOX_IP}": multipass_k8s_instance["ip"],
+        "${MLOX_PORT}": "22",
+        "${MLOX_ROOT}": "root",
+        "${MLOX_ROOT_PW}": "pass",
+        "${K3S_CONTROLLER_URL}": "",
+        "${K3S_CONTROLLER_TOKEN}": "",
+        "${K3S_CONTROLLER_UUID}": "",
+    }
+    bundle = add_server(infra, config, params)
+    if not bundle:
+        pytest.fail("Failed to add k3s server to infrastructure")
+    server = bundle.server
+    server.setup()
+    wait_for_k3s_ready(server)
+    yield server
+    logging.info(
+        f"Tearing down ubuntu_k3s_server on VM {multipass_k8s_instance['name']}..."
+    )
+    try:
+        server.teardown()
+        logging.info("Successfully tore down ubuntu_k3s_server.")
+    except Exception as e:
+        logging.warning(f"Could not tear down ubuntu_k3s_server: {e}")
     infra.remove_bundle(bundle)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_server
+from tests.integration.helpers import add_server, remove_server
 import uuid
 import time
 import socket
@@ -278,7 +278,7 @@ def ubuntu_docker_server(multipass_instance):
         logging.info("Successfully tore down ubuntu_docker_server.")
     except Exception as e:
         logging.warning(f"Could not tear down ubuntu_docker_server: {e}")
-    infra.remove_bundle(bundle)
+    infra.bundles.remove(bundle)
 
 
 @pytest.fixture(scope="package")
@@ -341,12 +341,11 @@ def ubuntu_k3s_server(multipass_k8s_instance):
     logging.info(
         f"Tearing down ubuntu_k3s_server on VM {multipass_k8s_instance['name']}..."
     )
-    try:
-        server.teardown()
+    result = remove_server(infra, server.ip)
+    if result.success:
         logging.info("Successfully tore down ubuntu_k3s_server.")
-    except Exception as e:
-        logging.warning(f"Could not tear down ubuntu_k3s_server: {e}")
-    infra.remove_bundle(bundle)
+    else:
+        logging.warning("Could not tear down ubuntu_k3s_server: %s", result.message)
 
 
 @pytest.fixture(scope="package")
@@ -386,7 +385,7 @@ def ubuntu_simple_server(ubuntu_docker_server, multipass_instance):
         logging.info("Successfully tore down ubuntu_simple_server.")
     except Exception as e:
         logging.warning(f"Could not tear down ubuntu_simple_server: {e}")
-    infra.remove_bundle(bundle)
+    infra.bundles.remove(bundle)
 
 
 # @pytest.fixture(scope="package")
@@ -413,4 +412,4 @@ def ubuntu_simple_server(ubuntu_docker_server, multipass_instance):
 #         logging.info("Successfully tore down ubuntu_native_server.")
 #     except Exception as e:
 #         logging.warning(f"Could not tear down ubuntu_native_server: {e}")
-#     infra.remove_bundle(bundle)
+#     infra.bundles.remove(bundle)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -273,12 +273,11 @@ def ubuntu_docker_server(multipass_instance):
         logging.warning(
             "Baseline docker volumes removed during teardown: %s", missing_volumes
         )
-    try:
-        server.teardown()
+    result = remove_server(infra, server.ip)
+    if result.success:
         logging.info("Successfully tore down ubuntu_docker_server.")
-    except Exception as e:
-        logging.warning(f"Could not tear down ubuntu_docker_server: {e}")
-    infra.bundles.remove(bundle)
+    else:
+        logging.warning("Could not tear down ubuntu_docker_server: %s", result.message)
 
 
 @pytest.fixture(scope="package")
@@ -381,11 +380,13 @@ def ubuntu_simple_server(ubuntu_docker_server, multipass_instance):
     )
     try:
         server.disable_debug_access()
-        server.teardown()
-        logging.info("Successfully tore down ubuntu_simple_server.")
     except Exception as e:
-        logging.warning(f"Could not tear down ubuntu_simple_server: {e}")
-    infra.bundles.remove(bundle)
+        logging.warning(f"Could not disable debug access before teardown: {e}")
+    result = remove_server(infra, server.ip)
+    if result.success:
+        logging.info("Successfully tore down ubuntu_simple_server.")
+    else:
+        logging.warning("Could not tear down ubuntu_simple_server: %s", result.message)
 
 
 # @pytest.fixture(scope="package")
@@ -412,4 +413,4 @@ def ubuntu_simple_server(ubuntu_docker_server, multipass_instance):
 #         logging.info("Successfully tore down ubuntu_native_server.")
 #     except Exception as e:
 #         logging.warning(f"Could not tear down ubuntu_native_server: {e}")
-#     infra.bundles.remove(bundle)
+#     remove_server(infra, server.ip)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -47,3 +47,13 @@ def add_service(
     if not result.success:
         return None
     return infrastructure.get_bundle_by_ip(server_ip)
+
+
+def remove_server(infrastructure: Infrastructure, server_ip: str):
+    project = WorkspaceState(name="integration-test", infrastructure=infrastructure)
+    return servers.teardown_server(project, ip=server_ip)
+
+
+def remove_service(infrastructure: Infrastructure, service_name: str):
+    project = WorkspaceState(name="integration-test", infrastructure=infrastructure)
+    return services.teardown_service(project, name=service_name)

--- a/tests/integration/test_kubernetes_server.py
+++ b/tests/integration/test_kubernetes_server.py
@@ -1,0 +1,20 @@
+import pytest
+
+from mlox.executors import TaskGroup
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.kubernetes]
+
+
+def test_k3s_server_reports_ready_node(ubuntu_k3s_server):
+    with ubuntu_k3s_server.get_server_connection(force_root=True) as conn:
+        nodes = ubuntu_k3s_server.exec.execute(
+            conn,
+            "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes --no-headers",
+            group=TaskGroup.KUBERNETES,
+            sudo=True,
+            pty=False,
+        )
+
+    assert nodes
+    assert " Ready " in f" {nodes} "

--- a/tests/integration/test_kubernetes_server.py
+++ b/tests/integration/test_kubernetes_server.py
@@ -7,7 +7,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.kubernetes]
 
 
 def test_k3s_server_reports_ready_node(ubuntu_k3s_server):
-    with ubuntu_k3s_server.get_server_connection(force_root=True) as conn:
+    with ubuntu_k3s_server.get_server_connection() as conn:
         nodes = ubuntu_k3s_server.exec.execute(
             conn,
             "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get nodes --no-headers",

--- a/tests/integration/test_kubernetes_services.py
+++ b/tests/integration/test_kubernetes_services.py
@@ -1,0 +1,96 @@
+import json
+import logging
+
+import pytest
+
+from mlox.config import get_stacks_path, load_config
+from mlox.infra import Bundle, Infrastructure
+from tests.integration.conftest import wait_for_service_ready
+from tests.integration.helpers import add_service, remove_service
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.kubernetes]
+logger = logging.getLogger(__name__)
+
+
+def _add_kubernetes_service(ubuntu_k3s_server, service_dir: str, config_name: str):
+    infra = Infrastructure()
+    bundle = Bundle(name=ubuntu_k3s_server.ip, server=ubuntu_k3s_server)
+    infra.bundles.append(bundle)
+
+    config = load_config(get_stacks_path(), service_dir, config_name)
+    bundle_added = add_service(infra, ubuntu_k3s_server.ip, config, params={})
+    if not bundle_added:
+        pytest.skip(f"Failed to add Kubernetes service from config {config_name}")
+    service = bundle_added.services[-1]
+    return infra, bundle_added, service
+
+
+def _remove_service(infra: Infrastructure, service_name: str) -> None:
+    result = remove_service(infra, service_name)
+    if not result.success:
+        logger.warning("Failed to remove Kubernetes service %s: %s", service_name, result.message)
+
+
+def _headlamp_status(service, bundle) -> dict[str, str]:
+    with bundle.server.get_server_connection() as conn:
+        status = service.exec.helm_status(
+            conn,
+            release=service.service_name,
+            namespace=service.namespace,
+            kubeconfig=service.kubeconfig,
+            output_format="json",
+        )
+    if not status:
+        return {"status": "unknown", "details": "helm status returned no output"}
+    try:
+        payload = json.loads(status)
+    except json.JSONDecodeError:
+        return {"status": "unknown", "details": status}
+    release_state = payload.get("info", {}).get("status", "unknown").lower()
+    return {
+        "status": "running" if release_state == "deployed" else "unknown",
+        "helm_status": release_state,
+    }
+
+
+def test_headlamp_service_installs_on_k3s(ubuntu_k3s_server):
+    infra, bundle, service = _add_kubernetes_service(
+        ubuntu_k3s_server,
+        "/k8s_headlamp",
+        "mlox.headlamp.yaml",
+    )
+    try:
+        with ubuntu_k3s_server.get_server_connection() as conn:
+            service.setup(conn)
+
+        status = wait_for_service_ready(
+            service,
+            bundle,
+            check_fn=lambda: _headlamp_status(service, bundle),
+            retries=18,
+            interval=10,
+        )
+        assert status.get("status") == "running"
+        assert service.service_urls.get("Headlamp", "").startswith("https://")
+        assert service.service_ports.get("Headlamp")
+    finally:
+        _remove_service(infra, service.name)
+
+
+def test_kubeapps_service_installs_on_k3s(ubuntu_k3s_server):
+    infra, bundle, service = _add_kubernetes_service(
+        ubuntu_k3s_server,
+        "/kubeapps",
+        "mlox.kubeapps.yaml",
+    )
+    try:
+        with ubuntu_k3s_server.get_server_connection() as conn:
+            service.setup(conn)
+
+        status = wait_for_service_ready(service, bundle, retries=24, interval=10)
+        assert status.get("status") == "running"
+        assert service.service_urls.get("KubeApps", "").startswith("https://")
+        assert service.service_ports.get("KubeApps")
+    finally:
+        _remove_service(infra, service.name)

--- a/tests/integration/test_service_airflow.py
+++ b/tests/integration/test_service_airflow.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import random
 import time
 import pytest
@@ -43,16 +43,9 @@ def install_airflow_service(ubuntu_docker_server):
     yield bundle_added, service
 
     # Teardown after tests
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service spin_down for teardown: {e}")
-        try:
-            service.teardown(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_airflow_service_is_running(install_airflow_service):

--- a/tests/integration/test_service_airflow.py
+++ b/tests/integration/test_service_airflow.py
@@ -52,7 +52,7 @@ def install_airflow_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as e:
             logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_airflow_service_is_running(install_airflow_service):

--- a/tests/integration/test_service_feast.py
+++ b/tests/integration/test_service_feast.py
@@ -97,7 +97,7 @@ def install_feast_service(ubuntu_docker_server):
         redis_service.spin_down(conn)
         redis_service.teardown(conn)
 
-    infra.remove_bundle(bundle)
+    infra.bundles.remove(bundle)
 
 
 def test_feast_service_is_running(install_feast_service):

--- a/tests/integration/test_service_feast.py
+++ b/tests/integration/test_service_feast.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import os
 import pytest
 from pathlib import Path
@@ -89,15 +89,12 @@ def install_feast_service(ubuntu_docker_server):
 
     yield infra, feast_bundle, feast_service, redis_service, postgres_service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        feast_service.spin_down(conn)
-        feast_service.teardown(conn)
-        postgres_service.spin_down(conn)
-        postgres_service.teardown(conn)
-        redis_service.spin_down(conn)
-        redis_service.teardown(conn)
-
-    infra.bundles.remove(bundle)
+    for service_to_remove in (feast_service, postgres_service, redis_service):
+        result = remove_service(infra, service_to_remove.name)
+        if not result.success:
+            logger.warning(
+                "Failed to remove service via application logic: %s", result.message
+            )
 
 
 def test_feast_service_is_running(install_feast_service):

--- a/tests/integration/test_service_github_repo.py
+++ b/tests/integration/test_service_github_repo.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import logging
 from datetime import datetime
 
@@ -87,15 +87,9 @@ def github_repo_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.teardown(conn)
-        except Exception as exc:  # pragma: no cover - teardown best effort
-            logger.warning(
-                "Ignoring error during GitHub repository service teardown: %s", exc
-            )
-
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_github_repo_public_clone(github_repo_service):
@@ -181,16 +175,9 @@ def github_private_repo_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.teardown(conn)
-        except Exception as exc:  # pragma: no cover - teardown best effort
-            logger.warning(
-                "Ignoring error during private GitHub repository service teardown: %s",
-                exc,
-            )
-
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_github_repo_private_clone(github_private_repo_service):

--- a/tests/integration/test_service_github_repo.py
+++ b/tests/integration/test_service_github_repo.py
@@ -95,7 +95,7 @@ def github_repo_service(ubuntu_docker_server):
                 "Ignoring error during GitHub repository service teardown: %s", exc
             )
 
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_github_repo_public_clone(github_repo_service):
@@ -190,7 +190,7 @@ def github_private_repo_service(ubuntu_docker_server):
                 exc,
             )
 
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_github_repo_private_clone(github_private_repo_service):

--- a/tests/integration/test_service_influx.py
+++ b/tests/integration/test_service_influx.py
@@ -46,7 +46,7 @@ def install_influx_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as e:
             logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_influx_service_is_running(install_influx_service):

--- a/tests/integration/test_service_influx.py
+++ b/tests/integration/test_service_influx.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import logging
 import pytest
 from influxdb import InfluxDBClient
@@ -37,16 +37,9 @@ def install_influx_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service spin_down for teardown: {e}")
-        try:
-            service.teardown(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_influx_service_is_running(install_influx_service):

--- a/tests/integration/test_service_kafka.py
+++ b/tests/integration/test_service_kafka.py
@@ -49,7 +49,7 @@ def install_kafka_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle)
+    infra.bundles.remove(bundle)
 
 
 def _write_certificate(tmp_path: Path, certificate: str) -> Path:

--- a/tests/integration/test_service_kafka.py
+++ b/tests/integration/test_service_kafka.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import uuid
 import logging
 from pathlib import Path
@@ -40,16 +40,9 @@ def install_kafka_service(ubuntu_docker_server):
 
     yield bundle, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def _write_certificate(tmp_path: Path, certificate: str) -> Path:

--- a/tests/integration/test_service_litellm.py
+++ b/tests/integration/test_service_litellm.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 
 """Integration tests for LiteLLM + Ollama service."""
 
@@ -45,16 +45,9 @@ def install_litellm_service(ubuntu_docker_server):
     yield bundle_added, service
 
     # Teardown after tests
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service spin_down for teardown: {e}")
-        try:
-            service.teardown(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_litellm_service_is_running(install_litellm_service):
@@ -108,7 +101,9 @@ def test_litellm_multiple_models_selection(ubuntu_docker_server):
     assert "qwen2.5:0.5b" in service.ollama_models
 
     # Cleanup (don't actually spin up to save test time)
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_litellm_no_models_selection(ubuntu_docker_server):
@@ -133,4 +128,6 @@ def test_litellm_no_models_selection(ubuntu_docker_server):
     assert len(service.ollama_models) == 0
 
     # Cleanup (don't actually spin up to save test time)
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)

--- a/tests/integration/test_service_litellm.py
+++ b/tests/integration/test_service_litellm.py
@@ -54,7 +54,7 @@ def install_litellm_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as e:
             logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_litellm_service_is_running(install_litellm_service):
@@ -108,7 +108,7 @@ def test_litellm_multiple_models_selection(ubuntu_docker_server):
     assert "qwen2.5:0.5b" in service.ollama_models
 
     # Cleanup (don't actually spin up to save test time)
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_litellm_no_models_selection(ubuntu_docker_server):
@@ -133,4 +133,4 @@ def test_litellm_no_models_selection(ubuntu_docker_server):
     assert len(service.ollama_models) == 0
 
     # Cleanup (don't actually spin up to save test time)
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)

--- a/tests/integration/test_service_milvus.py
+++ b/tests/integration/test_service_milvus.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import time
 import pytest
 
@@ -37,16 +37,9 @@ def install_milvus_service(ubuntu_docker_server):
     yield bundle_added, service
 
     # Teardown after tests
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_milvus_service_is_running(install_milvus_service):

--- a/tests/integration/test_service_milvus.py
+++ b/tests/integration/test_service_milvus.py
@@ -46,7 +46,7 @@ def install_milvus_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_milvus_service_is_running(install_milvus_service):

--- a/tests/integration/test_service_minio.py
+++ b/tests/integration/test_service_minio.py
@@ -45,7 +45,7 @@ def install_minio_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_minio_service_is_installed(install_minio_service):

--- a/tests/integration/test_service_minio.py
+++ b/tests/integration/test_service_minio.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import boto3
 import pytest
 
@@ -36,16 +36,9 @@ def install_minio_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_minio_service_is_installed(install_minio_service):

--- a/tests/integration/test_service_mlflow.py
+++ b/tests/integration/test_service_mlflow.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import os
 import time
 import pytest
@@ -48,16 +48,9 @@ def install_mlflow_service(ubuntu_docker_server):
     yield bundle_added, service
 
     # Teardown after tests
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_mlflow_service_is_running(install_mlflow_service):

--- a/tests/integration/test_service_mlflow.py
+++ b/tests/integration/test_service_mlflow.py
@@ -57,7 +57,7 @@ def install_mlflow_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_mlflow_service_is_running(install_mlflow_service):

--- a/tests/integration/test_service_mlflow3.py
+++ b/tests/integration/test_service_mlflow3.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import os
 import time
 import pytest
@@ -48,16 +48,9 @@ def install_mlflow3_service(ubuntu_docker_server):
     yield bundle_added, service
 
     # Teardown after tests
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_mlflow_service_is_running(install_mlflow3_service):

--- a/tests/integration/test_service_mlflow3.py
+++ b/tests/integration/test_service_mlflow3.py
@@ -57,7 +57,7 @@ def install_mlflow3_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_mlflow_service_is_running(install_mlflow3_service):

--- a/tests/integration/test_service_mlflow_gateway.py
+++ b/tests/integration/test_service_mlflow_gateway.py
@@ -101,7 +101,7 @@ def deploy_mlflow_gateway(ubuntu_docker_server, install_mlflow3_service):
             gateway_service.teardown(conn)
         except Exception as exc:
             logger.warning("Error during MLflow Gateway teardown: %s", exc)
-    infra.remove_bundle(gateway_bundle)
+    infra.bundles.remove(gateway_bundle)
 
 
 def test_mlflow_gateway_is_ready(deploy_mlflow_gateway):

--- a/tests/integration/test_service_mlflow_gateway.py
+++ b/tests/integration/test_service_mlflow_gateway.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import logging
 import os
 import time
@@ -92,16 +92,9 @@ def deploy_mlflow_gateway(ubuntu_docker_server, install_mlflow3_service):
 
     yield gateway_service, gateway_bundle, model_name, model_version
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            gateway_service.spin_down(conn)
-        except Exception as exc:
-            logger.warning("Error during MLflow Gateway spin_down: %s", exc)
-        try:
-            gateway_service.teardown(conn)
-        except Exception as exc:
-            logger.warning("Error during MLflow Gateway teardown: %s", exc)
-    infra.bundles.remove(gateway_bundle)
+    result = remove_service(infra, gateway_service.name)
+    if not result.success:
+        logger.warning("Failed to remove MLflow Gateway service via application logic: %s", result.message)
 
 
 def test_mlflow_gateway_is_ready(deploy_mlflow_gateway):

--- a/tests/integration/test_service_mlflow_mlserver.py
+++ b/tests/integration/test_service_mlflow_mlserver.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import os
 import time
 import logging
@@ -106,16 +106,9 @@ def deploy_mlflow_mlserver(ubuntu_docker_server, install_mlflow3_service):
 
     yield mlserver_service, bundle
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            mlserver_service.spin_down(conn)
-        except Exception as exc:
-            logger.warning("Error during MLServer spin_down: %s", exc)
-        try:
-            mlserver_service.teardown(conn)
-        except Exception as exc:
-            logger.warning("Error during MLServer teardown: %s", exc)
-    infra.bundles.remove(mlserver_bundle)
+    result = remove_service(infra, mlserver_service.name)
+    if not result.success:
+        logger.warning("Failed to remove MLServer service via application logic: %s", result.message)
 
 
 def test_mlserver_is_ready(deploy_mlflow_mlserver):

--- a/tests/integration/test_service_mlflow_mlserver.py
+++ b/tests/integration/test_service_mlflow_mlserver.py
@@ -115,7 +115,7 @@ def deploy_mlflow_mlserver(ubuntu_docker_server, install_mlflow3_service):
             mlserver_service.teardown(conn)
         except Exception as exc:
             logger.warning("Error during MLServer teardown: %s", exc)
-    infra.remove_bundle(mlserver_bundle)
+    infra.bundles.remove(mlserver_bundle)
 
 
 def test_mlserver_is_ready(deploy_mlflow_mlserver):

--- a/tests/integration/test_service_ollama.py
+++ b/tests/integration/test_service_ollama.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 
 """Integration tests for standalone Ollama service."""
 
@@ -43,16 +43,9 @@ def install_ollama_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as exc:
-            logger.warning("Ignoring error during Ollama spin_down: %s", exc)
-        try:
-            service.teardown(conn)
-        except Exception as exc:
-            logger.warning("Ignoring error during Ollama teardown: %s", exc)
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_ollama_service_is_running(install_ollama_service):

--- a/tests/integration/test_service_ollama.py
+++ b/tests/integration/test_service_ollama.py
@@ -52,7 +52,7 @@ def install_ollama_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as exc:
             logger.warning("Ignoring error during Ollama teardown: %s", exc)
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_ollama_service_is_running(install_ollama_service):

--- a/tests/integration/test_service_openbao.py
+++ b/tests/integration/test_service_openbao.py
@@ -43,7 +43,7 @@ def install_openbao_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle)
+    infra.bundles.remove(bundle)
 
 
 def test_openbao_service_is_running(install_openbao_service):

--- a/tests/integration/test_service_openbao.py
+++ b/tests/integration/test_service_openbao.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import pytest
 
 from mlox.config import load_config, get_stacks_path
@@ -34,16 +34,9 @@ def install_openbao_service(ubuntu_docker_server):
 
     yield infra, bundle, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_openbao_service_is_running(install_openbao_service):

--- a/tests/integration/test_service_otel.py
+++ b/tests/integration/test_service_otel.py
@@ -55,7 +55,7 @@ def install_otel_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception:
             pass
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_otel_service_is_running(install_otel_service):

--- a/tests/integration/test_service_otel.py
+++ b/tests/integration/test_service_otel.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import time
 import logging
 import grpc  # type: ignore
@@ -46,16 +46,9 @@ def install_otel_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception:
-            pass
-        try:
-            service.teardown(conn)
-        except Exception:
-            pass
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_otel_service_is_running(install_otel_service):

--- a/tests/integration/test_service_postgres.py
+++ b/tests/integration/test_service_postgres.py
@@ -45,7 +45,7 @@ def install_postgres_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as e:
             logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_postgres_service_is_running(install_postgres_service):

--- a/tests/integration/test_service_postgres.py
+++ b/tests/integration/test_service_postgres.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import pytest
 import logging
 
@@ -36,16 +36,9 @@ def install_postgres_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service spin_down for teardown: {e}")
-        try:
-            service.teardown(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_postgres_service_is_running(install_postgres_service):

--- a/tests/integration/test_service_redis.py
+++ b/tests/integration/test_service_redis.py
@@ -49,7 +49,7 @@ def install_redis_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as e:
             logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_redis_service_is_running(install_redis_service):

--- a/tests/integration/test_service_redis.py
+++ b/tests/integration/test_service_redis.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import logging
 import pytest
 import redis
@@ -40,16 +40,9 @@ def install_redis_service(ubuntu_docker_server):
     yield bundle_added, service
 
     # Teardown after tests
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service spin_down for teardown: {e}")
-        try:
-            service.teardown(conn)
-        except Exception as e:
-            logger.warning(f"Ignoring error during service teardown: {e}")
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_redis_service_is_running(install_redis_service):

--- a/tests/integration/test_service_registry.py
+++ b/tests/integration/test_service_registry.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import gzip
 import hashlib
 import io
@@ -46,16 +46,9 @@ def install_registry_service(ubuntu_docker_server):
 
     yield bundle_added, service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            service.spin_down(conn)
-        except Exception as exc:
-            logger.warning("Error during registry spin_down: %s", exc)
-        try:
-            service.teardown(conn)
-        except Exception as exc:
-            logger.warning("Error during registry teardown: %s", exc)
-    infra.bundles.remove(bundle_added)
+    result = remove_service(infra, service.name)
+    if not result.success:
+        logger.warning("Failed to remove service via application logic: %s", result.message)
 
 
 def test_registry_service_running(install_registry_service):

--- a/tests/integration/test_service_registry.py
+++ b/tests/integration/test_service_registry.py
@@ -55,7 +55,7 @@ def install_registry_service(ubuntu_docker_server):
             service.teardown(conn)
         except Exception as exc:
             logger.warning("Error during registry teardown: %s", exc)
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_registry_service_running(install_registry_service):

--- a/tests/integration/test_service_repo_deploy.py
+++ b/tests/integration/test_service_repo_deploy.py
@@ -80,7 +80,7 @@ def install_repo_deploy_service(ubuntu_docker_server):
         except Exception as exc:  # pragma: no cover - best effort
             logger.warning("Ignoring error during github repo teardown: %s", exc)
 
-    infra.remove_bundle(bundle_added)
+    infra.bundles.remove(bundle_added)
 
 
 def test_repo_deploy_setup_creates_compose_and_env(install_repo_deploy_service):

--- a/tests/integration/test_service_repo_deploy.py
+++ b/tests/integration/test_service_repo_deploy.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_service
+from tests.integration.helpers import add_service, remove_service
 import logging
 
 import pytest
@@ -70,17 +70,12 @@ def install_repo_deploy_service(ubuntu_docker_server):
 
     yield bundle_added, repo_service, deploy_service
 
-    with ubuntu_docker_server.get_server_connection() as conn:
-        try:
-            deploy_service.teardown(conn)
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.warning("Ignoring error during repo deploy teardown: %s", exc)
-        try:
-            repo_service.teardown(conn)
-        except Exception as exc:  # pragma: no cover - best effort
-            logger.warning("Ignoring error during github repo teardown: %s", exc)
-
-    infra.bundles.remove(bundle_added)
+    for service_to_remove in (deploy_service, repo_service):
+        result = remove_service(infra, service_to_remove.name)
+        if not result.success:
+            logger.warning(
+                "Failed to remove service via application logic: %s", result.message
+            )
 
 
 def test_repo_deploy_setup_creates_compose_and_env(install_repo_deploy_service):

--- a/tests/integration/test_ubuntu_server_multipass.py
+++ b/tests/integration/test_ubuntu_server_multipass.py
@@ -1,4 +1,4 @@
-from tests.integration.helpers import add_server
+from tests.integration.helpers import add_server, remove_server
 import logging
 import shutil
 import uuid
@@ -57,5 +57,4 @@ def test_multipass_ubuntu_server_lifecycle(template, expected_backend):
             assert conn.run("true", hide=True).ok
     finally:
         logging.info("Tearing down Multipass VM %s", name)
-        server.teardown()
-        infra.bundles.remove(bundle)
+        remove_server(infra, server.ip)

--- a/tests/integration/test_ubuntu_server_multipass.py
+++ b/tests/integration/test_ubuntu_server_multipass.py
@@ -58,4 +58,4 @@ def test_multipass_ubuntu_server_lifecycle(template, expected_backend):
     finally:
         logging.info("Tearing down Multipass VM %s", name)
         server.teardown()
-        infra.remove_bundle(bundle)
+        infra.bundles.remove(bundle)

--- a/tests/unit/service-render-fixture.tmpl
+++ b/tests/unit/service-render-fixture.tmpl
@@ -1,0 +1,5 @@
+name: @name
+quoted: @quoted
+block: |-
+@block
+shell: ${HOME} $$ not touched

--- a/tests/unit/services/test_dev_terminal_service.py
+++ b/tests/unit/services/test_dev_terminal_service.py
@@ -1,3 +1,4 @@
+from mlox.execution import TaskGroup
 from mlox.services.dev_terminal.service import DeveloperTerminalService
 
 
@@ -13,12 +14,14 @@ def _service() -> DeveloperTerminalService:
 def test_install_script_installs_modern_neovim_with_snap_when_needed() -> None:
     script = _service()._install_script()
 
+    assert "@install_" not in script
     assert "MIN_NVIM_VERSION=0.11.2" in script
     assert "nvim_version_meets_min" in script
     assert "snapd" in script
     assert "snap install nvim --classic" in script
     assert "ln -sf /snap/bin/nvim /usr/local/bin/nvim" in script
     assert "Neovim $MIN_NVIM_VERSION or newer is required for LazyVim." in script
+    assert "npm install -g @anthropic-ai/claude-code" in script
     assert " mc neovim nodejs " not in script
 
 
@@ -35,6 +38,7 @@ def test_check_requires_lazyvim_compatible_neovim() -> None:
     assert service.check(object()) == {"status": "running"}
     assert commands
     assert "nvim --version" in commands[0]
+    assert "command -v zsh git nvim mc yazi atuin claude pyenv tmux" in commands[0]
     assert 'dpkg --compare-versions "$nvim_version" ge 0.11.2' in commands[0]
 
 
@@ -77,4 +81,109 @@ def test_install_script_configures_utf8_locale_for_zsh_and_pyenv() -> None:
     assert "update-locale LANG=C.UTF-8 LC_CTYPE=C.UTF-8" in script
     assert "append_once 'export LANG=C.UTF-8'" in script
     assert "append_once 'export LC_CTYPE=C.UTF-8'" in script
+    assert "append_once 'export COLORTERM=truecolor'" in script
+    assert (
+        'append_once \'export TERMINFO_DIRS="$HOME/.terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo"\''
+        in script
+    )
+    assert "append_once 'export NCURSES_NO_UTF8_ACS=1'" in script
+    assert "append_once 'export LESSCHARSET=utf-8'" in script
     assert "append_once 'unset LC_ALL'" in script
+
+
+def test_install_script_installs_and_configures_tmux_for_lazyvim() -> None:
+    script = _service()._install_script()
+
+    assert " tmux " in script
+    assert " screen " not in script
+    assert "ncurses-bin ncurses-term" in script
+    assert 'TMUX_CONF="$TARGET_HOME/.tmux.conf"' in script
+    assert 'set -g default-terminal "tmux-256color"' in script
+    assert 'set -ga terminal-overrides ",*:RGB"' in script
+    assert 'set -g focus-events on' in script
+    assert 'set -g escape-time 10' in script
+    assert 'set -g mouse on' in script
+    assert 'setw -g mode-keys vi' in script
+    assert 'set -g set-clipboard on' in script
+    assert 'set -g prefix C-a' in script
+    assert 'bind | split-window -h -c "#{pane_current_path}"' in script
+    assert 'bind - split-window -v -c "#{pane_current_path}"' in script
+    assert 'bind h select-pane -L' in script
+    assert 'bind-key -T copy-mode-vi v send -X begin-selection' in script
+    assert 'bind ? display-popup -E -w 78 -h 24 "cat ~/.tmux-shortcuts"' in script
+
+
+def test_install_script_writes_tmux_shortcut_reference() -> None:
+    script = _service()._install_script()
+
+    assert 'TMUX_SHORTCUTS="$TARGET_HOME/.tmux-shortcuts"' in script
+    assert "tmux essentials for this host" in script
+    assert "tmux new -As dev" in script
+    assert "Ctrl-a |      split right" in script
+    assert "Ctrl-a h/j/k/l move between panes" in script
+    assert "Ctrl-a [      enter copy mode" in script
+    assert 'alias mux="tmux new -As dev"' in script
+    assert 'alias tmux-help="cat ~/.tmux-shortcuts"' in script
+
+
+def test_install_script_installs_oh_my_zsh_without_interactive_installer() -> None:
+    script = _service()._install_script()
+
+    assert "INSTALL_OH_MY_ZSH=true" in script
+    assert "https://github.com/ohmyzsh/ohmyzsh.git" in script
+    assert 'append_once \'export ZSH="$HOME/.oh-my-zsh"\'' in script
+    assert "append_once 'plugins=(git direnv fzf pyenv)'" in script
+    assert 'append_once \'[ -f "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"\'' in script
+
+
+def test_sensitive_cleanup_removes_claude_code_and_history_state() -> None:
+    script = _service()._sensitive_cleanup_script()
+
+    assert "TARGET_USER=\"${SUDO_USER:-$(id -un)}\"" in script
+    assert "remove_home_path" in script
+    assert 'rm -rf -- "$TARGET_HOME/$relative_path"' in script
+    assert 'remove_home_path ".claude"' in script
+    assert 'remove_home_path ".claude.json"' in script
+    assert 'remove_home_path ".config/claude-code"' in script
+    assert 'remove_home_path ".cache/claude-code"' in script
+    assert 'remove_home_path ".local/share/claude-code"' in script
+    assert 'remove_home_path ".local/state/claude-code"' in script
+    assert 'remove_home_path ".atuin"' in script
+    assert 'remove_home_path ".local/share/atuin"' in script
+    assert 'remove_home_path ".tmux.conf"' in script
+    assert 'remove_home_path ".tmux-shortcuts"' in script
+
+
+def test_teardown_runs_sensitive_cleanup_before_removing_target_path() -> None:
+    service = _service()
+    calls: list[tuple[str, str, dict]] = []
+
+    class Exec:
+        def fs_write_file(self, _conn, path, content):
+            calls.append(("fs_write_file", path, {"content": content}))
+
+        def execute(self, _conn, command, **kwargs):
+            calls.append(("execute", command, kwargs))
+
+        def fs_delete_dir(self, _conn, path):
+            calls.append(("fs_delete_dir", path, {}))
+
+    service.exec = Exec()  # type: ignore[assignment]
+
+    service.teardown(object())
+
+    assert calls[0][0] == "fs_write_file"
+    assert calls[0][1] == "/tmp/dev-terminal/cleanup-sensitive-state.sh"
+    assert 'remove_home_path ".claude"' in calls[0][2]["content"]
+    assert calls[1] == (
+        "execute",
+        "chmod +x /tmp/dev-terminal/cleanup-sensitive-state.sh",
+        {"group": TaskGroup.FILESYSTEM},
+    )
+    assert calls[2] == (
+        "execute",
+        "/tmp/dev-terminal/cleanup-sensitive-state.sh",
+        {"group": TaskGroup.SECURITY_ASSETS, "sudo": True},
+    )
+    assert calls[3] == ("fs_delete_dir", "/tmp/dev-terminal", {})
+    assert service.state == "un-initialized"

--- a/tests/unit/test_infra.py
+++ b/tests/unit/test_infra.py
@@ -211,6 +211,22 @@ def test_infrastructure_lookup_helpers_find_services_bundles_and_servers():
     assert infra.get_server_by_uuid("missing") is None
 
 
+def test_remove_bundle_removes_existing_bundle_and_reports_missing():
+    first_bundle = Bundle(name="first", server=make_server(GitServer, "10.0.0.1"))
+    second_bundle = Bundle(
+        name="second", server=make_server(FirewallServer, "10.0.0.2")
+    )
+    missing_bundle = Bundle(
+        name="missing", server=make_server(DummyServer, "10.0.0.3")
+    )
+    infra = make_infra(bundles=[first_bundle, second_bundle])
+
+    assert infra.remove_bundle(first_bundle) is True
+    assert infra.bundles == [second_bundle]
+    assert infra.remove_bundle(missing_bundle) is False
+    assert infra.bundles == [second_bundle]
+
+
 def test_kubernetes_and_backend_filters_only_return_matching_bundles():
     running_k8s_server = make_server(DummyServer, "10.0.0.1")
     running_k8s_server.backend = ["kubernetes"]

--- a/tests/unit/test_infra.py
+++ b/tests/unit/test_infra.py
@@ -211,21 +211,6 @@ def test_infrastructure_lookup_helpers_find_services_bundles_and_servers():
     assert infra.get_server_by_uuid("missing") is None
 
 
-def test_remove_bundle_removes_existing_bundle_and_reports_missing():
-    first_bundle = Bundle(name="first", server=make_server(GitServer, "10.0.0.1"))
-    second_bundle = Bundle(
-        name="second", server=make_server(FirewallServer, "10.0.0.2")
-    )
-    missing_bundle = Bundle(
-        name="missing", server=make_server(DummyServer, "10.0.0.3")
-    )
-    infra = make_infra(bundles=[first_bundle, second_bundle])
-
-    assert infra.remove_bundle(first_bundle) is True
-    assert infra.bundles == [second_bundle]
-    assert infra.remove_bundle(missing_bundle) is False
-    assert infra.bundles == [second_bundle]
-
 
 def test_kubernetes_and_backend_filters_only_return_matching_bundles():
     running_k8s_server = make_server(DummyServer, "10.0.0.1")

--- a/tests/unit/test_service_templates.py
+++ b/tests/unit/test_service_templates.py
@@ -6,7 +6,10 @@ from typing import Dict
 import pytest
 
 from mlox.service import AbstractService
+from mlox.services.k8s_headlamp.k8s import K8sHeadlampService
+from mlox.services.kubeapps.k8s import KubeAppsService
 from mlox.services.kubeflow.k8s import KubeflowService
+from mlox.services.mlflow_gateway.k3s import MLFlowGatewayK3sService
 from mlox.services.mlflow_mlserver.k3s import MLFlowMLServerK3sService
 
 
@@ -120,3 +123,120 @@ def test_mlflow_mlserver_k3s_manifest_template_renders_valid_documents() -> None
     assert f"nodePort: {service.port}" in rendered
     assert "${" not in rendered
     assert "@" not in rendered
+
+
+def test_kubeapps_templates_render_expected_resources() -> None:
+    service = KubeAppsService(
+        name="KubeApps",
+        service_config_id="kubeapps",
+        template="unused",
+        target_path="/tmp/kubeapps",
+    )
+
+    ingress = service.render_template(
+        "ingress.yaml.tmpl",
+        {
+            "ingress_name": "kubeapps-ingress",
+            "namespace": service.namespace,
+            "entrypoint": "websecure",
+            "host_line": "    - http:",
+            "path": "/kubeapps",
+            "release_name": service.release_name,
+            "backend_service_port": 80,
+            "tls_hosts": " []",
+            "tls_secret_name": "kubeapps-ingress-tls",
+        },
+    )
+    binding = service.render_template(
+        "admin-binding.yaml.tmpl",
+        {
+            "service_account_name": service.service_account_name,
+            "namespace": service.namespace,
+            "binding_name": service._cluster_role_binding_name(),
+        },
+    )
+
+    assert "kind: Ingress" in ingress
+    assert "path: /kubeapps" in ingress
+    assert "kind: ServiceAccount" in binding
+    assert "kind: ClusterRoleBinding" in binding
+    assert "@" not in ingress + binding
+
+
+def test_headlamp_templates_render_expected_resources() -> None:
+    service = K8sHeadlampService(
+        name="Headlamp",
+        service_config_id="headlamp",
+        template="unused",
+        target_path="/tmp/headlamp",
+    )
+
+    ingress = service.render_template(
+        "ingress.yaml.tmpl",
+        {
+            "ingress_name": "headlamp-ingress",
+            "namespace": service.namespace,
+            "annotations_block": "    kubernetes.io/ingress.class: traefik",
+            "path": "/headlamp",
+            "service_name": service.service_name,
+            "backend_port": 8080,
+        },
+    )
+    middleware = service.render_template(
+        "middleware.yaml.tmpl",
+        {
+            "middleware_name": "headlamp-strip-prefix",
+            "namespace": service.namespace,
+            "path": "/headlamp",
+        },
+    )
+    values = service.render_template(
+        "gadgets-values.yaml.tmpl", {"service_name": service.service_name}
+    )
+    binding = service.render_template(
+        "cluster-admin-binding.yaml.tmpl",
+        {
+            "binding_name": "headlamp-cluster-admin",
+            "service_name": service.service_name,
+            "namespace": service.namespace,
+        },
+    )
+
+    rendered = ingress + middleware + values + binding
+    assert "kind: Ingress" in ingress
+    assert "kind: Middleware" in middleware
+    assert f'claimName: "{service.service_name}"' in values
+    assert "kind: ClusterRoleBinding" in binding
+    assert "@" not in rendered
+
+
+def test_mlflow_gateway_k3s_templates_render_expected_resources(tmp_path) -> None:
+    serve_script = tmp_path / "serve.py"
+    serve_script.write_text("print('gateway')\n", encoding="utf-8")
+    service = MLFlowGatewayK3sService(
+        name="MLflow Gateway",
+        service_config_id="mlflow-gateway-3.8.1-k3s",
+        template="unused",
+        target_path="/tmp/mlflow-gateway",
+        dockerfile="unused",
+        serve_script=str(serve_script),
+        start_script="unused",
+        port=30433,
+        tracking_uri="https://mlflow.example.test",
+        tracking_user="user",
+        tracking_pw="pw",
+        requirements_txt="pydantic==2.0.0",
+    )
+
+    manifest = service._render_gateway_manifest()
+    values = service._render_traefik_values()
+
+    assert "kind: ConfigMap" in manifest
+    assert "kind: Secret" in manifest
+    assert "kind: Deployment" in manifest
+    assert "print('gateway')" in manifest
+    assert "pydantic==2.0.0" in manifest
+    assert f"namespace: {service.namespace}" in manifest
+    assert f"exposedPort: {service.port}" in values
+    assert "gateway-auth" in values
+    assert "@" not in manifest + values

--- a/tests/unit/test_service_templates.py
+++ b/tests/unit/test_service_templates.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pytest
+
+from mlox.service import AbstractService
+from mlox.services.kubeflow.k8s import KubeflowService
+from mlox.services.mlflow_mlserver.k3s import MLFlowMLServerK3sService
+
+
+@dataclass
+class DummyTemplateService(AbstractService):
+    def setup(self, conn) -> None:
+        pass
+
+    def teardown(self, conn) -> None:
+        pass
+
+    def check(self, conn) -> Dict:
+        return {"status": "running"}
+
+    def get_secrets(self) -> Dict[str, Dict]:
+        return {}
+
+    def spin_up(self, conn) -> bool:
+        return True
+
+    def spin_down(self, conn) -> bool:
+        return True
+
+
+def _dummy_service() -> DummyTemplateService:
+    return DummyTemplateService(
+        name="dummy",
+        service_config_id="dummy",
+        template="unused",
+        target_path="/tmp/dummy",
+    )
+
+
+def test_render_template_resolves_next_to_service_module() -> None:
+    service = _dummy_service()
+
+    rendered = service.render_template(
+        "service-render-fixture.tmpl",
+        {
+            "name": "mlox",
+            "quoted": service.yaml_scalar("value:with:colon"),
+            "block": service.indent_block("line one\nline two", 2),
+        },
+    )
+
+    assert "name: mlox" in rendered
+    assert 'quoted: "value:with:colon"' in rendered
+    assert "  line one" in rendered
+    assert "  line two" in rendered
+    assert "${HOME} $$ not touched" in rendered
+
+
+def test_render_template_reports_missing_template() -> None:
+    service = _dummy_service()
+
+    with pytest.raises(FileNotFoundError, match="does-not-exist.tmpl"):
+        service.render_template("does-not-exist.tmpl", {})
+
+
+def test_render_template_reports_missing_variable() -> None:
+    service = _dummy_service()
+
+    with pytest.raises(KeyError, match="name"):
+        service.render_template("service-render-fixture.tmpl", {})
+
+
+def test_kubeflow_traefik_values_template_renders_valid_yaml() -> None:
+    service = KubeflowService(
+        name="Kubeflow",
+        service_config_id="kubeflow",
+        template="unused",
+        target_path="/tmp/kubeflow",
+    )
+
+    rendered = service.render_template(
+        "kubeflow-traefik-values.yaml.tmpl",
+        {
+            "ingress_service": service.ingress_service,
+            "ingress_namespace": service.ingress_namespace,
+            "ingress_port": service.ingress_port,
+        },
+    )
+    assert f"port: {service.ingress_port}" in rendered
+    assert f"exposedPort: {service.ingress_port}" in rendered
+    assert "type: LoadBalancer" in rendered
+    assert (
+        "http://istio-ingressgateway.istio-system.svc.cluster.local:80" in rendered
+    )
+
+
+def test_mlflow_mlserver_k3s_manifest_template_renders_valid_documents() -> None:
+    service = MLFlowMLServerK3sService(
+        name="MLFlow-MLServer",
+        service_config_id="mlflow-mlserver-3.8.1-k3s",
+        template="unused",
+        target_path="/tmp/mlflow-mlserver",
+        dockerfile="unused",
+        port=30432,
+        model="demo-model/1",
+        tracking_uri="https://mlflow.example.test",
+        tracking_user="user",
+        tracking_pw="pw",
+    )
+
+    rendered = service._render_manifest()
+    assert "kind: Namespace" in rendered
+    assert "kind: Deployment" in rendered
+    assert "kind: Service" in rendered
+    assert f"name: {service.namespace}" in rendered
+    assert f"name: {service.deployment_name}" in rendered
+    assert f"nodePort: {service.port}" in rendered
+    assert "${" not in rendered
+    assert "@" not in rendered

--- a/tests/unit/tui/test_dashboard_tabs.py
+++ b/tests/unit/tui/test_dashboard_tabs.py
@@ -11,6 +11,7 @@ from textual.app import App, ComposeResult
 from textual.containers import Container
 from textual.widgets import TabbedContent
 
+from mlox.tui.screens.dashboard.tree import InfraTree
 from mlox.tui.screens.dashboard.app_log_panel import AppLogPanel
 from mlox.tui.screens.dashboard.model import SelectionInfo
 from mlox.tui.screens.dashboard.screen import (
@@ -74,6 +75,35 @@ def test_root_highlights_active_secret_manager() -> None:
     assert asyncio.run(_root_label()) == (
         "test-project  Secrets: Embedded Project Storage"
     )
+
+
+async def _leaf_flags_for_server_and_services() -> tuple[bool, bool, bool]:
+    app = DashboardTestApp()
+    server = SimpleNamespace(ip="10.0.0.5")
+    services = [SimpleNamespace(name="MLflow"), SimpleNamespace(name="Postgres")]
+    bundle = SimpleNamespace(name="dev", server=server, services=services)
+    app.workspace.infrastructure = SimpleNamespace(bundles=[bundle])
+
+    async with app.run_test():
+        tree = app.query_one(InfraTree)
+        bundle_node = tree.root.children[0]
+        server_node = bundle_node.children[0]
+        service_node = bundle_node.children[1]
+        return (
+            bundle_node.allow_expand,
+            server_node.allow_expand,
+            service_node.allow_expand,
+        )
+
+
+def test_server_and_service_tree_entries_are_leaf_nodes() -> None:
+    bundle_allows_expand, server_allows_expand, service_allows_expand = asyncio.run(
+        _leaf_flags_for_server_and_services()
+    )
+
+    assert bundle_allows_expand is True
+    assert server_allows_expand is False
+    assert service_allows_expand is False
 
 
 def test_bundle_selection_shows_only_service_templates_tab() -> None:

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -89,6 +89,7 @@ Key tasks:
 | `task ui:textual:terminal` | Launch the TUI |
 | `task tests:unit:run` | Run unit tests (fast, no external deps) |
 | `task tests:integration:run` | Run integration tests (requires Multipass VMs) |
+| `task tests:integration:k8s` | Run Kubernetes integration tests (requires Multipass/k3s) |
 | `task docker:up` / `docker:down` | Spin up/down the local Docker stack |
 | `task vm:start` | Start a Multipass test VM |
 
@@ -98,6 +99,7 @@ Key tasks:
 |-------|----------|-------------|
 | Unit tests | [`tests/unit/`](https://github.com/BusySloths/mlox/blob/main/tests/unit/) | Environment only |
 | Integration tests | [`tests/integration/`](https://github.com/BusySloths/mlox/blob/main/tests/integration/) | Multipass VMs |
+| Kubernetes integration tests | [`tests/integration/`](https://github.com/BusySloths/mlox/blob/main/tests/integration/) marked `kubernetes` | Multipass/k3s |
 
 ### Top-Level Directory Map
 

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -61,6 +61,9 @@ task tests:unit:run
 
 # Integration tests (requires Multipass VMs)
 task tests:integration:run
+
+# Kubernetes integration tests (requires Multipass/k3s)
+task tests:integration:k8s
 ```
 
 ### VM Setup for Integration Testing

--- a/wiki/Services-Catalog.md
+++ b/wiki/Services-Catalog.md
@@ -120,7 +120,7 @@ A reference to the ML/AI infrastructure services and integrations currently incl
 
 | Service | Version(s) | Description | Status |
 |---------|-----------|-------------|--------|
-| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, Atuin, Midnight Commander, Yazi, LazyVim integrations for Yazi and Claude Code, Spaceship prompt, git, pyenv-based Python version management, and useful terminal utilities; OpenSSH is expected from the MLOX server bootstrap. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
+| **Developers Terminal Dream** | 0.1-beta | Native-host bootstrap for LazyVim, zsh, oh-my-zsh, Atuin, tmux, Midnight Commander, Yazi, LazyVim integrations for Yazi and Claude Code, Spaceship prompt, git, pyenv-based Python version management, and useful terminal utilities; OpenSSH is expected from the MLOX server bootstrap. Advertised for native, Docker, and Kubernetes-capable backends because all three expose a remote Ubuntu host where developers can use these tools. | Beta |
 
 ---
 


### PR DESCRIPTION
### Motivation

- Provide a small, consistent templating mechanism for service artifacts so manifests and values files can be authored as templates next to service code. 
- Replace large f-string manifest construction with file-based templates to improve readability and maintainability. 
- Add tests and integration fixtures to validate template rendering and basic Kubernetes readiness behavior.

### Description

- Add `MloxTemplate` (``@`` delimiter) and helper methods to `AbstractService`: `service_dir`, `render_template`, `render_template_to_file`, `yaml_scalar`, and `indent_block`. 
- Replace inline manifest/value generation with template rendering in `kubeflow/k8s.py` and `mlflow_mlserver/k3s.py`, and add the corresponding template files `kubeflow-traefik-values.yaml.tmpl` and `mlserver-manifest.yaml.tmpl`. 
- Include service templates in package data by adding `mlox = ["services/**/*.tmpl"]` to `pyproject.toml`. 
- Add unit tests for template rendering (`tests/unit/test_service_templates.py`) and a fixture template file (`tests/unit/service-render-fixture.tmpl`). 
- Add Kubernetes-related integration fixtures and readiness helper in `tests/integration/conftest.py`, register new pytest markers, and add an integration test `tests/integration/test_kubernetes_server.py` that checks a k3s node reports Ready.

### Testing

- Added unit tests under `tests/unit` and ran `pytest tests/unit -q`, which passed. 
- Added an integration test marked `kubernetes` that depends on Multipass/k3s and is skipped when the environment lacks Multipass, and is intended to be exercised in environments with Multipass; CI will skip it if Multipass is unavailable. 
- Updated `pytest.ini` to register the new `kubernetes` and `slow` markers and enable live logging during test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3397a14f9c8322a3abde340f60561d)