### PR TITLE
feat(mlflow): add secret-managed TLS k3s gateway variant

### DIFF
--- a/mlox/execution/kubernetes.py
+++ b/mlox/execution/kubernetes.py
@@ -13,37 +13,6 @@ from mlox.execution.base import TaskGroup, TaskRunnerABC, _quote_command
 
 
 class KubernetesMixin(TaskRunnerABC):
-    def k8s_ensure_namespace(
-        self,
-        connection: Connection,
-        namespace: str,
-        *,
-        kubeconfig: str | None = None,
-        sudo: bool = True,
-    ) -> str | None:
-        """Idempotently create a namespace without a persistent manifest."""
-
-        create_parts = [
-            "kubectl",
-            "create",
-            "namespace",
-            namespace,
-            "--dry-run=client",
-            "-o",
-            "yaml",
-        ]
-        apply_parts = ["kubectl", "apply", "-f", "-"]
-        if kubeconfig:
-            create_parts.extend(["--kubeconfig", kubeconfig])
-            apply_parts.extend(["--kubeconfig", kubeconfig])
-        command = f"{_quote_command(create_parts)} | {_quote_command(apply_parts)}"
-        return self._run_task(
-            connection,
-            group=TaskGroup.KUBERNETES,
-            command=command,
-            sudo=sudo,
-        )
-
     def k8s_apply_tls_secret(
         self,
         connection: Connection,
@@ -101,7 +70,11 @@ class KubernetesMixin(TaskRunnerABC):
             if kubeconfig:
                 create_parts.extend(["--kubeconfig", kubeconfig])
                 apply_parts.extend(["--kubeconfig", kubeconfig])
-            command = f"{_quote_command(create_parts)} | {_quote_command(apply_parts)}"
+            pipeline = f"{_quote_command(create_parts)} | {_quote_command(apply_parts)}"
+            # Keep both sides of the pipe inside the privileged shell. Fabric's
+            # sudo wrapper may otherwise elevate only the first kubectl process,
+            # leaving `kubectl apply` unable to read the root-owned k3s config.
+            command = _quote_command(["sh", "-c", pipeline])
             return self._run_task(
                 connection,
                 group=TaskGroup.KUBERNETES,

--- a/mlox/execution/kubernetes.py
+++ b/mlox/execution/kubernetes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import secrets
+from io import BytesIO
 from typing import Any, Mapping, Sequence
 
 from fabric import Connection  # type: ignore
@@ -11,6 +13,113 @@ from mlox.execution.base import TaskGroup, TaskRunnerABC, _quote_command
 
 
 class KubernetesMixin(TaskRunnerABC):
+    def k8s_ensure_namespace(
+        self,
+        connection: Connection,
+        namespace: str,
+        *,
+        kubeconfig: str | None = None,
+        sudo: bool = True,
+    ) -> str | None:
+        """Idempotently create a namespace without a persistent manifest."""
+
+        create_parts = [
+            "kubectl",
+            "create",
+            "namespace",
+            namespace,
+            "--dry-run=client",
+            "-o",
+            "yaml",
+        ]
+        apply_parts = ["kubectl", "apply", "-f", "-"]
+        if kubeconfig:
+            create_parts.extend(["--kubeconfig", kubeconfig])
+            apply_parts.extend(["--kubeconfig", kubeconfig])
+        command = f"{_quote_command(create_parts)} | {_quote_command(apply_parts)}"
+        return self._run_task(
+            connection,
+            group=TaskGroup.KUBERNETES,
+            command=command,
+            sudo=sudo,
+        )
+
+    def k8s_apply_tls_secret(
+        self,
+        connection: Connection,
+        name: str,
+        *,
+        namespace: str,
+        certificate: str,
+        private_key: str,
+        kubeconfig: str | None = None,
+        sudo: bool = True,
+    ) -> str | None:
+        """Create or update a TLS Secret without recording PEM data in history."""
+
+        suffix = secrets.token_hex(16)
+        temp_dir = f"/tmp/mlox_tls_{suffix}"
+        cert_path = f"{temp_dir}/tls.crt"
+        key_path = f"{temp_dir}/tls.key"
+        try:
+            prepare = _quote_command(["mkdir", "-m", "700", temp_dir])
+            if (
+                self._run_task(
+                    connection,
+                    group=TaskGroup.SECURITY_ASSETS,
+                    command=prepare,
+                    sudo=False,
+                )
+                is None
+            ):
+                return None
+            connection.put(BytesIO(certificate.encode("utf-8")), remote=cert_path)
+            connection.put(BytesIO(private_key.encode("utf-8")), remote=key_path)
+
+            create_parts = [
+                "kubectl",
+                "create",
+                "secret",
+                "tls",
+                name,
+                "--namespace",
+                namespace,
+                f"--cert={cert_path}",
+                f"--key={key_path}",
+                "--dry-run=client",
+                "-o",
+                "yaml",
+            ]
+            apply_parts = [
+                "kubectl",
+                "apply",
+                "-f",
+                "-",
+                "--namespace",
+                namespace,
+            ]
+            if kubeconfig:
+                create_parts.extend(["--kubeconfig", kubeconfig])
+                apply_parts.extend(["--kubeconfig", kubeconfig])
+            command = f"{_quote_command(create_parts)} | {_quote_command(apply_parts)}"
+            return self._run_task(
+                connection,
+                group=TaskGroup.KUBERNETES,
+                command=command,
+                sudo=sudo,
+            )
+        finally:
+            cleanup = (
+                f"{_quote_command(['rm', '-f', cert_path, key_path])} "
+                f"&& {_quote_command(['rmdir', temp_dir])}"
+            )
+            self._run_task(
+                connection,
+                group=TaskGroup.SECURITY_ASSETS,
+                command=cleanup,
+                sudo=sudo,
+            )
+
     def helm_repo_add(
         self,
         connection: Connection,

--- a/mlox/service.py
+++ b/mlox/service.py
@@ -39,6 +39,7 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
+    cast,
 )
 from dataclasses import dataclass, field, asdict
 
@@ -631,6 +632,21 @@ class AbstractService(ABC):
         if lookup is None:
             return None
         return lookup.get_service_by_name(service_name)
+
+    def get_dependent_secret_manager(
+        self, service_uuid: str
+    ) -> "AbstractSecretManager":
+        """Resolve a secret manager through the runtime-only service lookup."""
+
+        lookup = self._service_lookup
+        if lookup is None:
+            raise ValueError("Service dependency lookup is not available.")
+        service = self.get_dependent_service(service_uuid)
+        if not isinstance(service, AbstractSecretManagerService):
+            raise ValueError(
+                f"Service {service_uuid} is not an available secret manager service."
+            )
+        return service.get_secret_manager(cast("Infrastructure", lookup))
 
     def dump_state(self, conn) -> None:
         """Persist service debugging artifacts to the target directory."""

--- a/mlox/service.py
+++ b/mlox/service.py
@@ -33,13 +33,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Collection,
     Dict,
     List,
     Literal,
     Mapping,
     Optional,
     Protocol,
-    cast,
 )
 from dataclasses import dataclass, field, asdict
 
@@ -615,13 +615,35 @@ class AbstractService(ABC):
             return "No log labels configured for this service."
         return self.compose_service_log_tail(conn, label=chosen_label, tail=tail)
 
-    def get_dependent_service(self, service_uuid: str) -> Optional["AbstractService"]:
-        """Get a dependent service by UUID via the bound service lookup."""
+    def get_dependent_service(
+        self,
+        service_uuid: str,
+        *,
+        required_type: type[Any] | tuple[type[Any], ...] | None = None,
+        required_capabilities: Collection[ServiceCapability | str] = (),
+    ) -> Optional["AbstractService"]:
+        """Get a compatible dependent service by UUID via the bound lookup."""
 
         lookup = self._service_lookup
         if lookup is None:
             return None
-        return lookup.get_service_by_uuid(service_uuid)
+        service = lookup.get_service_by_uuid(service_uuid)
+        if service is None:
+            return None
+        if required_type is not None and not isinstance(service, required_type):
+            return None
+
+        available_capabilities = {
+            capability.value if isinstance(capability, ServiceCapability) else str(capability)
+            for capability in (getattr(service, "capabilities", set()) or set())
+        }
+        expected_capabilities = {
+            capability.value if isinstance(capability, ServiceCapability) else str(capability)
+            for capability in required_capabilities
+        }
+        if not expected_capabilities.issubset(available_capabilities):
+            return None
+        return service
 
     def get_dependent_service_by_name(
         self, service_name: str
@@ -632,21 +654,6 @@ class AbstractService(ABC):
         if lookup is None:
             return None
         return lookup.get_service_by_name(service_name)
-
-    def get_dependent_secret_manager(
-        self, service_uuid: str
-    ) -> "AbstractSecretManager":
-        """Resolve a secret manager through the runtime-only service lookup."""
-
-        lookup = self._service_lookup
-        if lookup is None:
-            raise ValueError("Service dependency lookup is not available.")
-        service = self.get_dependent_service(service_uuid)
-        if not isinstance(service, AbstractSecretManagerService):
-            raise ValueError(
-                f"Service {service_uuid} is not an available secret manager service."
-            )
-        return service.get_secret_manager(cast("Infrastructure", lookup))
 
     def dump_state(self, conn) -> None:
         """Persist service debugging artifacts to the target directory."""

--- a/mlox/services/mlflow_gateway/README.md
+++ b/mlox/services/mlflow_gateway/README.md
@@ -17,19 +17,20 @@ requirements, the maximum cached models, and the cache TTL.
 MLOX generates gateway credentials. Docker deployments also get an external
 port; k3s deployments use a generated URL path on the k3s Traefik endpoint.
 
-The managed-TLS k3s variant additionally selects a hostname and an existing
-MLOX secret-manager entry. The entry must contain the matching certificate and
-private key as one structured value:
+The managed-TLS k3s variant additionally selects an existing MLOX
+secret-manager entry. The entry must contain the hostname, matching
+certificate, and private key as one structured value:
 
 ```json
 {
-  "tls.crt": "-----BEGIN CERTIFICATE-----...",
-  "tls.key": "-----BEGIN PRIVATE KEY-----..."
+  "tls.hostname": "gateway.example.org",
+  "tls.crt": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
+  "tls.key": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 }
 ```
 
-Only the hostname, secret-manager service UUID, and secret name are persisted
-with the gateway. The PEM values are loaded and validated during setup.
+Only the secret-manager service UUID and secret name are persisted with the
+gateway. The hostname and PEM values are loaded and validated during setup.
 
 ## Usage
 

--- a/mlox/services/mlflow_gateway/README.md
+++ b/mlox/services/mlflow_gateway/README.md
@@ -9,12 +9,27 @@ In MLOX, add an MLflow model registry first, then select one gateway service:
 
 - `mlflow-gateway-3.8.1-docker`
 - `mlflow-gateway-3.8.1-k3s`
+- `mlflow-gateway-3.8.1-k3s-managed-tls`
 
 During setup, select the registry and optionally configure additional Python
 requirements, the maximum cached models, and the cache TTL.
 
 MLOX generates gateway credentials. Docker deployments also get an external
 port; k3s deployments use a generated URL path on the k3s Traefik endpoint.
+
+The managed-TLS k3s variant additionally selects a hostname and an existing
+MLOX secret-manager entry. The entry must contain the matching certificate and
+private key as one structured value:
+
+```json
+{
+  "tls.crt": "-----BEGIN CERTIFICATE-----...",
+  "tls.key": "-----BEGIN PRIVATE KEY-----..."
+}
+```
+
+Only the hostname, secret-manager service UUID, and secret name are persisted
+with the gateway. The PEM values are loaded and validated during setup.
 
 ## Usage
 
@@ -93,10 +108,28 @@ Pitfalls:
 - The k3s HTTPS ingress port must be allowed by the host firewall.
 - Credentials are stored in a Kubernetes Secret; protect cluster access.
 
+### Managed TLS variant
+
+The managed-TLS variant inherits the regular k3s deployment and remains a
+separate catalog entry for now. It creates one additional namespace-local
+`kubernetes.io/tls` Secret and configures the existing Traefik Ingress with the
+selected hostname and TLS Secret. It does not install or reconfigure Traefik.
+
+Certificate material is retrieved through the gateway service's runtime-bound
+dependency lookup. It is uploaded through protected temporary files that are
+removed after the Kubernetes Secret is applied; it is not written into the
+persistent gateway manifest or MLOX service state. Updating the referenced
+secret and running setup again rotates the Kubernetes Secret.
+
+Cloudflare Origin Certificates are intended for the Cloudflare-to-origin
+connection. Direct clients generally do not trust them; use the Cloudflare
+hostname/proxy path or a publicly trusted certificate for direct access.
+
 ## Common Limitations
 
-- TLS uses Traefik's default self-signed certificate. Use `curl -k` or
-  `verify=False`, or install trusted certificate handling separately.
+- The regular Docker and k3s variants use Traefik's default self-signed
+  certificate. Use `curl -k` or `verify=False`. The managed-TLS k3s variant
+  uses the selected certificate instead.
 - MLflow tracking TLS verification is disabled for compatibility with MLOX's
   self-signed deployments.
 - The model cache is process-local and is cleared on restart.

--- a/mlox/services/mlflow_gateway/__init__.py
+++ b/mlox/services/mlflow_gateway/__init__.py
@@ -2,5 +2,10 @@
 
 from .docker import MLFlowGatewayDockerService
 from .k3s import MLFlowGatewayK3sService
+from .k3s_managed_tls import MLFlowGatewayManagedTlsK3sService
 
-__all__ = ["MLFlowGatewayDockerService", "MLFlowGatewayK3sService"]
+__all__ = [
+    "MLFlowGatewayDockerService",
+    "MLFlowGatewayK3sService",
+    "MLFlowGatewayManagedTlsK3sService",
+]

--- a/mlox/services/mlflow_gateway/gateway-managed-tls-manifest.yaml.tmpl
+++ b/mlox/services/mlflow_gateway/gateway-managed-tls-manifest.yaml.tmpl
@@ -1,0 +1,196 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: @namespace
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mlflow-gateway-code
+  namespace: @namespace
+data:
+  serve.py: |-
+@serve_script_block
+  gateway-requirements.txt: |-
+@requirements_block
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlflow-gateway-credentials
+  namespace: @namespace
+type: Opaque
+stringData:
+  gateway-user: @gateway_user
+  gateway-password: @gateway_password
+  tracking-uri: @tracking_uri
+  tracking-user: @tracking_user
+  tracking-password: @tracking_password
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: @basic_auth_secret
+  namespace: @namespace
+type: Opaque
+stringData:
+  users: @basic_auth_user
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: @deployment_name
+  namespace: @namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mlflow-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mlflow-gateway
+    spec:
+      containers:
+        - name: gateway
+          image: python:3.12-slim
+          imagePullPolicy: IfNotPresent
+          workingDir: /app
+          command: ["/bin/bash", "-lc"]
+          args:
+            - |
+              set -euo pipefail
+              pip install --no-cache-dir \
+                "mlflow==3.8.1" \
+                "mlflow[extras]==3.8.1" \
+                "fastapi==0.115.0" \
+                "uvicorn[standard]==0.30.6" \
+                "prometheus-client==0.21.1" \
+                "pandas>=2.2" \
+                "numpy>=1.26"
+              if [ -s /app/gateway-requirements.txt ]; then
+                pip install --no-cache-dir -r /app/gateway-requirements.txt
+              fi
+              exec uvicorn serve:app --host 0.0.0.0 --port @container_port
+          env:
+            - name: MLFLOW_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-uri
+            - name: MLFLOW_TRACKING_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-uri
+            - name: MLFLOW_TRACKING_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-user
+            - name: MLFLOW_TRACKING_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-gateway-credentials
+                  key: tracking-password
+            - name: MLFLOW_TRACKING_INSECURE_TLS
+              value: "true"
+            - name: MLOX_GATEWAY_CACHE_MAX_MODELS
+              value: @cache_size
+            - name: MLOX_GATEWAY_CACHE_TTL_DAYS
+              value: @cache_ttl
+          ports:
+            - name: http
+              containerPort: @container_port
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 6
+          volumeMounts:
+            - name: gateway-code
+              mountPath: /app/serve.py
+              subPath: serve.py
+              readOnly: true
+            - name: gateway-code
+              mountPath: /app/gateway-requirements.txt
+              subPath: gateway-requirements.txt
+              readOnly: true
+      volumes:
+        - name: gateway-code
+          configMap:
+            name: mlflow-gateway-code
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: @service_name
+  namespace: @namespace
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mlflow-gateway
+  ports:
+    - name: http
+      port: @container_port
+      targetPort: http
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: @basic_auth_middleware
+  namespace: @namespace
+spec:
+  basicAuth:
+    secret: @basic_auth_secret
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: @strip_prefix_middleware
+  namespace: @namespace
+spec:
+  stripPrefix:
+    prefixes:
+      - @ingress_path
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: @ingress_name
+  namespace: @namespace
+  annotations:
+    kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.middlewares: @namespace-@basic_auth_middleware@@kubernetescrd,@namespace-@strip_prefix_middleware@@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - @tls_hostname
+      secretName: @tls_secret_name
+  rules:
+    - host: @tls_hostname
+      http:
+        paths:
+          - path: @ingress_path
+            pathType: Prefix
+            backend:
+              service:
+                name: @service_name
+                port:
+                  number: @container_port

--- a/mlox/services/mlflow_gateway/k3s.py
+++ b/mlox/services/mlflow_gateway/k3s.py
@@ -97,6 +97,8 @@ class MLFlowGatewayK3sService(MLFlowGatewayDockerService):
             self.state = "unknown"
             return
 
+        self._after_manifest_apply(conn)
+
         rollout = self.exec.execute(
             conn,
             self._kubectl(
@@ -118,6 +120,10 @@ class MLFlowGatewayK3sService(MLFlowGatewayDockerService):
         self.service_urls["MLflow Gateway REST API"] = self.service_url
         self.service_ports["MLflow Gateway REST API"] = self.ingress_port
         self.state = "running"
+
+    def _after_manifest_apply(self, conn) -> None:
+        """Run variant-specific setup after the namespace manifest is applied."""
+        return None
 
     def spin_up(self, conn) -> bool:
         return True

--- a/mlox/services/mlflow_gateway/k3s_managed_tls.py
+++ b/mlox/services/mlflow_gateway/k3s_managed_tls.py
@@ -11,6 +11,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from passlib.hash import apr_md5_crypt
 
+from mlox.service import AbstractSecretManagerService, ServiceCapability
 from mlox.services.mlflow_gateway.docker import _resolved_setting, _resolved_text
 from mlox.services.mlflow_gateway.k3s import MLFlowGatewayK3sService
 
@@ -37,7 +38,16 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
         if not _valid_hostname(self.tls_hostname):
             raise ValueError("A valid TLS hostname is required.")
 
-        manager = self.get_dependent_secret_manager(self.tls_secret_manager_uuid)
+        manager_service = self.get_dependent_service(
+            self.tls_secret_manager_uuid,
+            required_type=AbstractSecretManagerService,
+            required_capabilities={ServiceCapability.SECRET_MANAGER},
+        )
+        if not isinstance(manager_service, AbstractSecretManagerService):
+            raise ValueError(
+                f"Service {self.tls_secret_manager_uuid} is not an available secret manager."
+            )
+        manager = manager_service.get_secret_manager(self._service_lookup)
         secret = manager.load_secret(self.tls_secret_name)
         if not isinstance(secret, dict):
             raise ValueError("The TLS secret must be an object with tls.crt and tls.key.")

--- a/mlox/services/mlflow_gateway/k3s_managed_tls.py
+++ b/mlox/services/mlflow_gateway/k3s_managed_tls.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -14,6 +15,8 @@ from passlib.hash import apr_md5_crypt
 from mlox.service import AbstractSecretManagerService, ServiceCapability
 from mlox.services.mlflow_gateway.docker import _resolved_setting, _resolved_text
 from mlox.services.mlflow_gateway.k3s import MLFlowGatewayK3sService
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -29,6 +32,7 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
         # Runtime-only: the hostname is loaded from the referenced secret and is
         # intentionally excluded from persisted service state.
         self._tls_hostname = ""
+        self._tls_material: tuple[str, str] | None = None
         self.tls_kubernetes_secret_name = f"mlflow-gateway-tls-{self.gateway_id}"
 
     def _load_and_validate_tls_material(self) -> tuple[str, str]:
@@ -105,14 +109,30 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
 
     def setup(self, conn) -> None:
         certificate, private_key = self._load_and_validate_tls_material()
+        self._tls_material = (certificate, private_key)
+        try:
+            super().setup(conn)
+            if self.state != "running":
+                raise RuntimeError("Failed to apply the MLflow Gateway manifest.")
+        except Exception:
+            try:
+                super().teardown(conn)
+            except Exception:
+                logger.exception(
+                    "Failed to roll back managed-TLS gateway namespace %s.",
+                    self.namespace,
+                )
+            raise
+        finally:
+            self._tls_material = None
 
-        if (
-            self.exec.k8s_ensure_namespace(
-                conn, self.namespace, kubeconfig=self.kubeconfig
-            )
-            is None
-        ):
-            raise RuntimeError("Failed to create the MLflow Gateway namespace.")
+        self.service_url = f"https://{self._tls_hostname}{self.ingress_path}"
+        self.service_urls["MLflow Gateway REST API"] = self.service_url
+
+    def _after_manifest_apply(self, conn) -> None:
+        if self._tls_material is None:
+            raise RuntimeError("TLS material was not prepared for gateway setup.")
+        certificate, private_key = self._tls_material
         if (
             self.exec.k8s_apply_tls_secret(
                 conn,
@@ -125,12 +145,6 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
             is None
         ):
             raise RuntimeError("Failed to apply the MLflow Gateway TLS secret.")
-
-        super().setup(conn)
-        if self.state != "running":
-            raise RuntimeError("Failed to apply the MLflow Gateway manifest.")
-        self.service_url = f"https://{self._tls_hostname}{self.ingress_path}"
-        self.service_urls["MLflow Gateway REST API"] = self.service_url
 
 
 def _valid_hostname(hostname: str) -> bool:

--- a/mlox/services/mlflow_gateway/k3s_managed_tls.py
+++ b/mlox/services/mlflow_gateway/k3s_managed_tls.py
@@ -20,14 +20,15 @@ from mlox.services.mlflow_gateway.k3s import MLFlowGatewayK3sService
 class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
     """Expose the gateway through k3s Traefik with externally managed TLS."""
 
-    tls_hostname: str = ""
     tls_secret_manager_uuid: str = ""
     tls_secret_name: str = ""
     tls_kubernetes_secret_name: str = field(init=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        self.tls_hostname = self.tls_hostname.strip().rstrip(".").lower()
+        # Runtime-only: the hostname is loaded from the referenced secret and is
+        # intentionally excluded from persisted service state.
+        self._tls_hostname = ""
         self.tls_kubernetes_secret_name = f"mlflow-gateway-tls-{self.gateway_id}"
 
     def _load_and_validate_tls_material(self) -> tuple[str, str]:
@@ -35,8 +36,6 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
             raise ValueError("A TLS secret-manager service is required.")
         if not self.tls_secret_name:
             raise ValueError("A TLS secret name is required.")
-        if not _valid_hostname(self.tls_hostname):
-            raise ValueError("A valid TLS hostname is required.")
 
         manager_service = self.get_dependent_service(
             self.tls_secret_manager_uuid,
@@ -50,15 +49,24 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
         manager = manager_service.get_secret_manager(self._service_lookup)
         secret = manager.load_secret(self.tls_secret_name)
         if not isinstance(secret, dict):
-            raise ValueError("The TLS secret must be an object with tls.crt and tls.key.")
+            raise ValueError(
+                "The TLS secret must be an object with tls.hostname, tls.crt, and tls.key."
+            )
+        hostname = secret.get("tls.hostname")
         certificate = secret.get("tls.crt")
         private_key = secret.get("tls.key")
+        if not isinstance(hostname, str) or not _valid_hostname(
+            hostname.strip().rstrip(".").lower()
+        ):
+            raise ValueError("The TLS secret does not contain a valid tls.hostname.")
+        hostname = hostname.strip().rstrip(".").lower()
         if not isinstance(certificate, str) or not certificate.strip():
             raise ValueError("The TLS secret does not contain a non-empty tls.crt.")
         if not isinstance(private_key, str) or not private_key.strip():
             raise ValueError("The TLS secret does not contain a non-empty tls.key.")
 
-        _validate_certificate(certificate, private_key, self.tls_hostname)
+        _validate_certificate(certificate, private_key, hostname)
+        self._tls_hostname = hostname
         return certificate, private_key
 
     def _render_gateway_manifest(self) -> str:
@@ -90,7 +98,7 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
                 "cache_size": self.yaml_scalar(cache_size),
                 "cache_ttl": self.yaml_scalar(cache_ttl),
                 "service_name": self.service_name,
-                "tls_hostname": self.yaml_scalar(self.tls_hostname),
+                "tls_hostname": self.yaml_scalar(self._tls_hostname),
                 "tls_secret_name": self.tls_kubernetes_secret_name,
             },
         )
@@ -121,7 +129,7 @@ class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
         super().setup(conn)
         if self.state != "running":
             raise RuntimeError("Failed to apply the MLflow Gateway manifest.")
-        self.service_url = f"https://{self.tls_hostname}{self.ingress_path}"
+        self.service_url = f"https://{self._tls_hostname}{self.ingress_path}"
         self.service_urls["MLflow Gateway REST API"] = self.service_url
 
 

--- a/mlox/services/mlflow_gateway/k3s_managed_tls.py
+++ b/mlox/services/mlflow_gateway/k3s_managed_tls.py
@@ -1,0 +1,176 @@
+"""k3s MLflow Gateway variant using secret-manager-backed TLS."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from passlib.hash import apr_md5_crypt
+
+from mlox.services.mlflow_gateway.docker import _resolved_setting, _resolved_text
+from mlox.services.mlflow_gateway.k3s import MLFlowGatewayK3sService
+
+
+@dataclass
+class MLFlowGatewayManagedTlsK3sService(MLFlowGatewayK3sService):
+    """Expose the gateway through k3s Traefik with externally managed TLS."""
+
+    tls_hostname: str = ""
+    tls_secret_manager_uuid: str = ""
+    tls_secret_name: str = ""
+    tls_kubernetes_secret_name: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.tls_hostname = self.tls_hostname.strip().rstrip(".").lower()
+        self.tls_kubernetes_secret_name = f"mlflow-gateway-tls-{self.gateway_id}"
+
+    def _load_and_validate_tls_material(self) -> tuple[str, str]:
+        if not self.tls_secret_manager_uuid:
+            raise ValueError("A TLS secret-manager service is required.")
+        if not self.tls_secret_name:
+            raise ValueError("A TLS secret name is required.")
+        if not _valid_hostname(self.tls_hostname):
+            raise ValueError("A valid TLS hostname is required.")
+
+        manager = self.get_dependent_secret_manager(self.tls_secret_manager_uuid)
+        secret = manager.load_secret(self.tls_secret_name)
+        if not isinstance(secret, dict):
+            raise ValueError("The TLS secret must be an object with tls.crt and tls.key.")
+        certificate = secret.get("tls.crt")
+        private_key = secret.get("tls.key")
+        if not isinstance(certificate, str) or not certificate.strip():
+            raise ValueError("The TLS secret does not contain a non-empty tls.crt.")
+        if not isinstance(private_key, str) or not private_key.strip():
+            raise ValueError("The TLS secret does not contain a non-empty tls.key.")
+
+        _validate_certificate(certificate, private_key, self.tls_hostname)
+        return certificate, private_key
+
+    def _render_gateway_manifest(self) -> str:
+        serve_script = Path(self.serve_script).read_text(encoding="utf-8")
+        requirements = _resolved_text(self.requirements_txt)
+        cache_size = _resolved_setting(self.cache_max_models, "10")
+        cache_ttl = _resolved_setting(self.cache_ttl_days, "10")
+        password_hash = apr_md5_crypt.hash(self.pw)
+
+        return self.render_template(
+            "gateway-managed-tls-manifest.yaml.tmpl",
+            {
+                "namespace": self.namespace,
+                "serve_script_block": self.indent_block(serve_script, 4),
+                "requirements_block": self.indent_block(requirements, 4),
+                "gateway_user": self.yaml_scalar(self.user),
+                "gateway_password": self.yaml_scalar(self.pw),
+                "basic_auth_secret": self.basic_auth_secret,
+                "basic_auth_user": self.yaml_scalar(f"{self.user}:{password_hash}"),
+                "basic_auth_middleware": self.basic_auth_middleware,
+                "strip_prefix_middleware": self.strip_prefix_middleware,
+                "ingress_name": self.ingress_name,
+                "ingress_path": self.yaml_scalar(self.ingress_path),
+                "tracking_uri": self.yaml_scalar(self.tracking_uri),
+                "tracking_user": self.yaml_scalar(self.tracking_user),
+                "tracking_password": self.yaml_scalar(self.tracking_pw),
+                "deployment_name": self.deployment_name,
+                "container_port": self.container_port,
+                "cache_size": self.yaml_scalar(cache_size),
+                "cache_ttl": self.yaml_scalar(cache_ttl),
+                "service_name": self.service_name,
+                "tls_hostname": self.yaml_scalar(self.tls_hostname),
+                "tls_secret_name": self.tls_kubernetes_secret_name,
+            },
+        )
+
+    def setup(self, conn) -> None:
+        certificate, private_key = self._load_and_validate_tls_material()
+
+        if (
+            self.exec.k8s_ensure_namespace(
+                conn, self.namespace, kubeconfig=self.kubeconfig
+            )
+            is None
+        ):
+            raise RuntimeError("Failed to create the MLflow Gateway namespace.")
+        if (
+            self.exec.k8s_apply_tls_secret(
+                conn,
+                self.tls_kubernetes_secret_name,
+                namespace=self.namespace,
+                certificate=certificate,
+                private_key=private_key,
+                kubeconfig=self.kubeconfig,
+            )
+            is None
+        ):
+            raise RuntimeError("Failed to apply the MLflow Gateway TLS secret.")
+
+        super().setup(conn)
+        if self.state != "running":
+            raise RuntimeError("Failed to apply the MLflow Gateway manifest.")
+        self.service_url = f"https://{self.tls_hostname}{self.ingress_path}"
+        self.service_urls["MLflow Gateway REST API"] = self.service_url
+
+
+def _valid_hostname(hostname: str) -> bool:
+    if not hostname or len(hostname) > 253:
+        return False
+    labels = hostname.split(".")
+    return len(labels) >= 2 and all(
+        re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", label)
+        for label in labels
+    )
+
+
+def _validate_certificate(certificate_pem: str, private_key_pem: str, hostname: str) -> None:
+    try:
+        certificates = x509.load_pem_x509_certificates(certificate_pem.encode("utf-8"))
+        private_key = serialization.load_pem_private_key(
+            private_key_pem.encode("utf-8"), password=None
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("The TLS certificate or private key is not valid PEM.") from exc
+    if not certificates:
+        raise ValueError("The TLS certificate does not contain a certificate.")
+    certificate = certificates[0]
+
+    now = datetime.now(timezone.utc)
+    if now < certificate.not_valid_before_utc or now > certificate.not_valid_after_utc:
+        raise ValueError("The TLS certificate is not currently valid.")
+
+    public_format = serialization.PublicFormat.SubjectPublicKeyInfo
+    certificate_key = certificate.public_key().public_bytes(
+        serialization.Encoding.DER, public_format
+    )
+    private_public_key = private_key.public_key().public_bytes(
+        serialization.Encoding.DER, public_format
+    )
+    if certificate_key != private_public_key:
+        raise ValueError("The TLS certificate and private key do not match.")
+
+    try:
+        names = certificate.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value.get_values_for_type(x509.DNSName)
+    except x509.ExtensionNotFound:
+        names = [
+            attribute.value
+            for attribute in certificate.subject.get_attributes_for_oid(
+                x509.NameOID.COMMON_NAME
+            )
+        ]
+    if not any(_hostname_matches(pattern, hostname) for pattern in names):
+        raise ValueError("The TLS certificate does not cover the configured hostname.")
+
+
+def _hostname_matches(pattern: str, hostname: str) -> bool:
+    pattern = pattern.strip().rstrip(".").lower()
+    if pattern.startswith("*."):
+        suffix = pattern[2:]
+        return hostname.endswith(f".{suffix}") and len(hostname.split(".")) == len(
+            suffix.split(".")
+        ) + 1
+    return pattern == hostname

--- a/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.managed-tls.k3s.yaml
+++ b/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.managed-tls.k3s.yaml
@@ -6,8 +6,8 @@ description_short: MLflow model gateway on k3s using secret-manager-backed TLS.
 description: Provides an authenticated HTTPS endpoint that loads MLflow pyfunc
   models dynamically from a configured MLflow registry. This distinct k3s
   variant uses the built-in Traefik ingress with a hostname certificate loaded
-  at setup time from an MLOX secret-manager service. Only the manager UUID,
-  secret name, and hostname are persisted by the service.
+  at setup time from an MLOX secret-manager service. Only the manager UUID and
+  secret name are persisted by the service.
 links:
   project: https://mlflow.org/
   news: https://mlflow.org/releases/
@@ -50,6 +50,5 @@ build:
     user: ${MLOX_AUTO_USER}
     pw: ${MLOX_AUTO_PW}
     registry_uuid: ${MODEL_REGISTRY_UUID}
-    tls_hostname: ${TLS_HOSTNAME}
     tls_secret_manager_uuid: ${TLS_SECRET_MANAGER_UUID}
     tls_secret_name: ${TLS_SECRET_NAME}

--- a/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.managed-tls.k3s.yaml
+++ b/mlox/services/mlflow_gateway/mlox.mlflow_gateway.3.8.1.managed-tls.k3s.yaml
@@ -1,0 +1,55 @@
+id: mlflow-gateway-3.8.1-k3s-managed-tls
+name: MLFlow Gateway (managed TLS)
+version: 3.8.1
+maintainer: Busy Sloths
+description_short: MLflow model gateway on k3s using secret-manager-backed TLS.
+description: Provides an authenticated HTTPS endpoint that loads MLflow pyfunc
+  models dynamically from a configured MLflow registry. This distinct k3s
+  variant uses the built-in Traefik ingress with a hostname certificate loaded
+  at setup time from an MLOX secret-manager service. Only the manager UUID,
+  secret name, and hostname are persisted by the service.
+links:
+  project: https://mlflow.org/
+  news: https://mlflow.org/releases/
+  security: https://mlflow.org/docs/latest/security.html
+  documentation: https://mlflow.org/docs/latest/index.html
+  changelog: https://mlflow.org/docs/latest/changelog.html
+requirements:
+  cpus: 1.0
+  ram_gb: 2.0
+  disk_gb: 2.0
+groups:
+  service: null
+  model-server: null
+  backend:
+    kubernetes: null
+capabilities:
+  service:
+  - model_server
+  - health
+  backend:
+  - kubernetes
+ports:
+  rest: 30433
+build:
+  class_name: mlox.services.mlflow_gateway.k3s_managed_tls.MLFlowGatewayManagedTlsK3sService
+  params:
+    name: mlflow-gateway-3.8.1-managed-tls
+    template: ${MLOX_STACKS_PATH}/mlflow_gateway/mlox.mlflow_gateway.3.8.1.managed-tls.k3s.yaml
+    target_path: ${MLOX_USER_HOME}/mlflow-gateway-3.8.1-k3s-managed-tls
+    dockerfile: ${MLOX_STACKS_PATH}/mlflow_gateway/dockerfile-mlflow-gateway-3.8.1
+    serve_script: ${MLOX_STACKS_PATH}/mlflow_gateway/serve.py
+    start_script: ${MLOX_STACKS_PATH}/mlflow_gateway/start_gateway.sh
+    port: ${MLOX_AUTO_PORT_REST}
+    tracking_uri: ${TRACKING_URI}
+    tracking_user: ${TRACKING_USER}
+    tracking_pw: ${TRACKING_PW}
+    requirements_txt: ${GATEWAY_REQUIREMENTS_TXT}
+    cache_max_models: ${GATEWAY_CACHE_MAX_MODELS}
+    cache_ttl_days: ${GATEWAY_CACHE_TTL_DAYS}
+    user: ${MLOX_AUTO_USER}
+    pw: ${MLOX_AUTO_PW}
+    registry_uuid: ${MODEL_REGISTRY_UUID}
+    tls_hostname: ${TLS_HOSTNAME}
+    tls_secret_manager_uuid: ${TLS_SECRET_MANAGER_UUID}
+    tls_secret_name: ${TLS_SECRET_NAME}

--- a/mlox/tui/services/__init__.py
+++ b/mlox/tui/services/__init__.py
@@ -23,6 +23,7 @@ _TUI_SERVICE_BINDINGS: dict[str, dict[str, tuple[str, ...]]] = {
         "config_ids": (
             "mlflow-gateway-3.8.1-docker",
             "mlflow-gateway-3.8.1-k3s",
+            "mlflow-gateway-3.8.1-k3s-managed-tls",
         ),
         "function_names": ("settings",),
     },

--- a/mlox/tui/services/setup.py
+++ b/mlox/tui/services/setup.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
-from mlox.service import ServiceCapability
+from mlox.service import AbstractSecretManagerService, ServiceCapability
 from mlox.tui.template_forms import TemplateFieldSpec, TemplateFormSpec
 
 
@@ -208,6 +209,28 @@ def mlflow_gateway(infra, bundle, config=None) -> TemplateFormSpec:
     )
 
 
+def mlflow_gateway_managed_tls(infra, bundle, config=None) -> TemplateFormSpec:
+    base = mlflow_gateway(infra, bundle, config)
+    return TemplateFormSpec(
+        title="Add MLflow Gateway (managed TLS)",
+        description=(
+            "Select a registry, hostname, and an existing structured TLS secret."
+        ),
+        fields=base.fields
+        + [
+            TemplateFieldSpec("tls_hostname", "TLS hostname"),
+            TemplateFieldSpec(
+                "tls_secret_ref",
+                "TLS secret (manager / name)",
+                kind="select",
+                options=_tls_secret_reference_options(infra),
+            ),
+        ],
+        submit_label="Add Service",
+        materialize=_materialize_gateway_managed_tls,
+    )
+
+
 def otel(infra, bundle, config=None) -> TemplateFormSpec:
     return TemplateFormSpec(
         title="Add OpenTelemetry Collector",
@@ -316,6 +339,44 @@ def _materialize_gateway(values: dict[str, str], infra) -> dict[str, str]:
         "${GATEWAY_CACHE_TTL_DAYS}": values.get("cache_ttl_days", "10"),
         "${MODEL_REGISTRY_UUID}": values["registry_uuid"],
     }
+
+
+def _materialize_gateway_managed_tls(
+    values: dict[str, str], infra
+) -> dict[str, str]:
+    params = _materialize_gateway(values, infra)
+    manager_uuid, secret_name = json.loads(values["tls_secret_ref"])
+    params.update(
+        {
+            "${TLS_HOSTNAME}": values["tls_hostname"],
+            "${TLS_SECRET_MANAGER_UUID}": manager_uuid,
+            "${TLS_SECRET_NAME}": secret_name,
+        }
+    )
+    return params
+
+
+def _tls_secret_reference_options(infra) -> list[tuple[str, str]]:
+    options: list[tuple[str, str]] = []
+    for service in _iter_services(infra):
+        if not isinstance(service, AbstractSecretManagerService):
+            continue
+        service_uuid = getattr(service, "uuid", "")
+        if not isinstance(service_uuid, str) or not service_uuid:
+            continue
+        try:
+            manager = service.get_secret_manager(infra)
+            names = sorted(manager.list_secrets(keys_only=True))
+        except Exception:
+            continue
+        options.extend(
+            (
+                f"{service.name} / {name}",
+                json.dumps([service_uuid, str(name)]),
+            )
+            for name in names
+        )
+    return options
 
 
 def _model_registry_options(infra) -> list[tuple[str, str]]:
@@ -427,6 +488,7 @@ SETUP_HANDLERS = {
     "mlflow-3.8.1-docker": no_params,
     "mlflow-gateway-3.8.1-docker": mlflow_gateway,
     "mlflow-gateway-3.8.1-k3s": mlflow_gateway,
+    "mlflow-gateway-3.8.1-k3s-managed-tls": mlflow_gateway_managed_tls,
     "mlflow-mlserver-2.22.0-docker": mlflow_mlserver,
     "mlflow-mlserver-3.8.1-docker": mlflow_mlserver,
     "mlflow-mlserver-3.8.1-k3s": mlflow_mlserver,

--- a/mlox/tui/services/setup.py
+++ b/mlox/tui/services/setup.py
@@ -214,11 +214,11 @@ def mlflow_gateway_managed_tls(infra, bundle, config=None) -> TemplateFormSpec:
     return TemplateFormSpec(
         title="Add MLflow Gateway (managed TLS)",
         description=(
-            "Select a registry, hostname, and an existing structured TLS secret."
+            "Select a registry and an existing structured TLS secret containing "
+            "tls.hostname, tls.crt, and tls.key."
         ),
         fields=base.fields
         + [
-            TemplateFieldSpec("tls_hostname", "TLS hostname"),
             TemplateFieldSpec(
                 "tls_secret_ref",
                 "TLS secret (manager / name)",
@@ -348,7 +348,6 @@ def _materialize_gateway_managed_tls(
     manager_uuid, secret_name = json.loads(values["tls_secret_ref"])
     params.update(
         {
-            "${TLS_HOSTNAME}": values["tls_hostname"],
             "${TLS_SECRET_MANAGER_UUID}": manager_uuid,
             "${TLS_SECRET_NAME}": secret_name,
         }

--- a/mlox/view/services/__init__.py
+++ b/mlox/view/services/__init__.py
@@ -90,6 +90,10 @@ _STREAMLIT_SERVICE_BINDINGS: dict[str, dict[str, tuple[str, ...]]] = {
         ),
         "function_names": ("settings", "setup"),
     },
+    "mlox.view.services.mlflow_gateway_managed_tls": {
+        "config_ids": ("mlflow-gateway-3.8.1-k3s-managed-tls",),
+        "function_names": ("settings", "setup"),
+    },
     "mlox.view.services.openbao": {
         "config_ids": ("openbao-docker",),
         "function_names": ("settings", "setup"),

--- a/mlox/view/services/mlflow_gateway_managed_tls.py
+++ b/mlox/view/services/mlflow_gateway_managed_tls.py
@@ -28,11 +28,6 @@ def setup(infra: Infrastructure, bundle: Bundle) -> dict | None:
         st.warning("No secret-manager service is available.")
         return None
 
-    hostname = st.text_input(
-        "TLS hostname",
-        placeholder="gateway.example.org",
-        key="mlflow_gateway_tls_hostname",
-    )
     manager_service = st.selectbox(
         "TLS secret manager",
         managers,
@@ -58,7 +53,6 @@ def setup(infra: Infrastructure, bundle: Bundle) -> dict | None:
 
     params.update(
         {
-            "${TLS_HOSTNAME}": hostname,
             "${TLS_SECRET_MANAGER_UUID}": manager_service.uuid,
             "${TLS_SECRET_NAME}": secret_name,
         }

--- a/mlox/view/services/mlflow_gateway_managed_tls.py
+++ b/mlox/view/services/mlflow_gateway_managed_tls.py
@@ -1,0 +1,66 @@
+"""Streamlit setup for the secret-manager-backed k3s gateway variant."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import streamlit as st
+
+from mlox.infra import Bundle, Infrastructure
+from mlox.service import AbstractSecretManagerService
+from mlox.view.services.mlflow_gateway import setup as gateway_setup
+from mlox.view.services.mlflow_gateway import settings
+
+__all__ = ["settings", "setup"]
+
+
+def setup(infra: Infrastructure, bundle: Bundle) -> dict | None:
+    params = gateway_setup(infra, bundle)
+    if params is None:
+        return None
+
+    managers = [
+        service
+        for service in infra.filter_by_group("secret-manager")
+        if isinstance(service, AbstractSecretManagerService)
+    ]
+    if not managers:
+        st.warning("No secret-manager service is available.")
+        return None
+
+    hostname = st.text_input(
+        "TLS hostname",
+        placeholder="gateway.example.org",
+        key="mlflow_gateway_tls_hostname",
+    )
+    manager_service = st.selectbox(
+        "TLS secret manager",
+        managers,
+        format_func=lambda service: service.name,
+        key="mlflow_gateway_tls_manager",
+    )
+    try:
+        manager = cast(
+            AbstractSecretManagerService, manager_service
+        ).get_secret_manager(infra)
+        secret_names = sorted(manager.list_secrets(keys_only=True))
+    except Exception as exc:
+        st.warning(f"Could not list TLS secrets: {exc}")
+        return None
+    if not secret_names:
+        st.warning("The selected secret manager does not contain any secrets.")
+        return None
+    secret_name = st.selectbox(
+        "TLS secret",
+        secret_names,
+        key="mlflow_gateway_tls_secret",
+    )
+
+    params.update(
+        {
+            "${TLS_HOSTNAME}": hostname,
+            "${TLS_SECRET_MANAGER_UUID}": manager_service.uuid,
+            "${TLS_SECRET_NAME}": secret_name,
+        }
+    )
+    return params

--- a/tests/unit/services/test_mlflow_gateway_k3s_managed_tls.py
+++ b/tests/unit/services/test_mlflow_gateway_k3s_managed_tls.py
@@ -85,15 +85,11 @@ class _Executor:
         self.calls: list[tuple] = []
         self.files: dict[str, str] = {}
         self.apply_result = "configured"
-        self.namespace_result = "namespace configured"
         self.tls_result = "secret configured"
+        self.delete_result = "namespace deleted"
 
     def _record(self, name, *args, **kwargs):
         self.calls.append((name, args, kwargs))
-
-    def k8s_ensure_namespace(self, conn, namespace, **kwargs):
-        self._record("k8s_ensure_namespace", namespace, **kwargs)
-        return self.namespace_result
 
     def k8s_apply_tls_secret(self, conn, name, **kwargs):
         self._record("k8s_apply_tls_secret", name, **kwargs)
@@ -109,6 +105,13 @@ class _Executor:
     def k8s_apply_manifest(self, conn, path, **kwargs):
         self._record("k8s_apply_manifest", path, **kwargs)
         return self.apply_result
+
+    def k8s_delete_resource(self, conn, *args, **kwargs):
+        self._record("k8s_delete_resource", *args, **kwargs)
+        return self.delete_result
+
+    def fs_delete_dir(self, conn, path):
+        self._record("fs_delete_dir", path)
 
     def execute(self, conn, command, **kwargs):
         self._record("execute", command, **kwargs)
@@ -168,7 +171,7 @@ def test_renders_host_tls_ingress_without_pem(managed_gateway) -> None:
     assert tls["tls.key"] not in manifest
 
 
-def test_setup_resolves_secret_through_bound_lookup_and_applies_tls_first(
+def test_setup_uses_gateway_manifest_namespace_then_applies_tls_secret(
     managed_gateway,
 ) -> None:
     service, tls, manager, manager_service, lookup = managed_gateway
@@ -176,9 +179,9 @@ def test_setup_resolves_secret_through_bound_lookup_and_applies_tls_first(
     service.setup(SimpleNamespace(host="10.0.0.4"))
 
     call_names = [call[0] for call in service.exec.calls]
-    assert call_names.index("k8s_ensure_namespace") < call_names.index(
+    assert call_names.index("k8s_apply_manifest") < call_names.index(
         "k8s_apply_tls_secret"
-    ) < call_names.index("k8s_apply_manifest")
+    ) < call_names.index("execute")
     tls_call = next(call for call in service.exec.calls if call[0] == "k8s_apply_tls_secret")
     assert tls_call[2]["certificate"] == tls["tls.crt"]
     assert tls_call[2]["private_key"] == tls["tls.key"]
@@ -189,6 +192,27 @@ def test_setup_resolves_secret_through_bound_lookup_and_applies_tls_first(
     )
     assert tls["tls.crt"] not in service.exec.files[service.manifest_path]
     assert tls["tls.key"] not in service.exec.files[service.manifest_path]
+
+
+@pytest.mark.parametrize("failure", ["manifest", "tls-secret"])
+def test_setup_failure_rolls_back_dedicated_namespace(
+    managed_gateway, failure
+) -> None:
+    service, _, _, _, _ = managed_gateway
+    if failure == "manifest":
+        service.exec.apply_result = None
+    else:
+        service.exec.tls_result = None
+
+    with pytest.raises(RuntimeError, match="Failed to apply"):
+        service.setup(SimpleNamespace(host="10.0.0.4"))
+
+    delete_call = next(
+        call for call in service.exec.calls if call[0] == "k8s_delete_resource"
+    )
+    assert delete_call[1][:2] == ("namespace", service.namespace)
+    assert delete_call[2]["ignore_not_found"] is True
+    assert service.state == "un-initialized"
 
 
 def test_validation_failure_happens_before_cluster_mutation(managed_gateway) -> None:

--- a/tests/unit/services/test_mlflow_gateway_k3s_managed_tls.py
+++ b/tests/unit/services/test_mlflow_gateway_k3s_managed_tls.py
@@ -38,6 +38,7 @@ def _tls_material(hostname: str = "gateway.example.org") -> dict[str, str]:
         .sign(key, hashes.SHA256())
     )
     return {
+        "tls.hostname": hostname,
         "tls.crt": certificate.public_bytes(serialization.Encoding.PEM).decode(),
         "tls.key": key.private_bytes(
             serialization.Encoding.PEM,
@@ -139,7 +140,6 @@ def managed_gateway(tmp_path: Path):
         requirements_txt="pydantic==2.0.0",
         user="gateway-user",
         pw="gateway-password",
-        tls_hostname="gateway.example.org",
         tls_secret_manager_uuid="manager-uuid",
         tls_secret_name="gateway-tls",
     )
@@ -151,6 +151,7 @@ def managed_gateway(tmp_path: Path):
 def test_renders_host_tls_ingress_without_pem(managed_gateway) -> None:
     service, tls, _, _, _ = managed_gateway
 
+    service._load_and_validate_tls_material()
     manifest = service._render_gateway_manifest()
     documents = list(yaml.safe_load_all(manifest))
     ingress = next(item for item in documents if item.get("kind") == "Ingress")
@@ -192,9 +193,26 @@ def test_setup_resolves_secret_through_bound_lookup_and_applies_tls_first(
 
 def test_validation_failure_happens_before_cluster_mutation(managed_gateway) -> None:
     service, _, manager, _, _ = managed_gateway
-    manager.value = {"tls.crt": "not a certificate", "tls.key": "not a key"}
+    manager.value = {
+        "tls.hostname": "gateway.example.org",
+        "tls.crt": "not a certificate",
+        "tls.key": "not a key",
+    }
 
     with pytest.raises(ValueError, match="valid PEM"):
+        service.setup(SimpleNamespace(host="10.0.0.4"))
+
+    assert service.exec.calls == []
+
+
+@pytest.mark.parametrize("hostname", [None, "", "localhost", "bad host.example"])
+def test_missing_or_invalid_secret_hostname_happens_before_cluster_mutation(
+    managed_gateway, hostname
+) -> None:
+    service, tls, manager, _, _ = managed_gateway
+    manager.value = {**tls, "tls.hostname": hostname}
+
+    with pytest.raises(ValueError, match="valid tls.hostname"):
         service.setup(SimpleNamespace(host="10.0.0.4"))
 
     assert service.exec.calls == []
@@ -219,8 +237,7 @@ def test_rejects_mismatched_key_and_uncovered_hostname(managed_gateway) -> None:
         service.setup(SimpleNamespace(host="10.0.0.4"))
     assert service.exec.calls == []
 
-    manager.value = tls
-    service.tls_hostname = "other.example.org"
+    manager.value = {**tls, "tls.hostname": "other.example.org"}
     with pytest.raises(ValueError, match="does not cover"):
         service.setup(SimpleNamespace(host="10.0.0.4"))
     assert service.exec.calls == []
@@ -235,9 +252,9 @@ def test_persistence_round_trip_contains_references_only(managed_gateway) -> Non
     restored = dict_to_dataclass(payload)
 
     assert isinstance(restored, MLFlowGatewayManagedTlsK3sService)
-    assert restored.tls_hostname == "gateway.example.org"
     assert restored.tls_secret_manager_uuid == "manager-uuid"
     assert restored.tls_secret_name == "gateway-tls"
+    assert "tls_hostname" not in payload
     assert tls["tls.crt"] not in serialized
     assert tls["tls.key"] not in serialized
 
@@ -259,7 +276,6 @@ def test_catalog_instantiates_managed_tls_variant() -> None:
             "${MLOX_AUTO_USER}": "gateway-user",
             "${MLOX_AUTO_PW}": "gateway-password",
             "${MODEL_REGISTRY_UUID}": "registry-uuid",
-            "${TLS_HOSTNAME}": "gateway.example.org",
             "${TLS_SECRET_MANAGER_UUID}": "manager-uuid",
             "${TLS_SECRET_NAME}": "gateway-tls",
         }

--- a/tests/unit/services/test_mlflow_gateway_k3s_managed_tls.py
+++ b/tests/unit/services/test_mlflow_gateway_k3s_managed_tls.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+from mlox.config import load_all_service_configs
+from mlox.service import AbstractSecretManagerService
+from mlox.services.mlflow_gateway.k3s_managed_tls import (
+    MLFlowGatewayManagedTlsK3sService,
+)
+from mlox.utils import dataclass_to_dict, dict_to_dataclass
+
+
+def _tls_material(hostname: str = "gateway.example.org") -> dict[str, str]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, hostname)]
+    )
+    now = datetime.now(timezone.utc)
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(x509.SubjectAlternativeName([x509.DNSName(hostname)]), False)
+        .sign(key, hashes.SHA256())
+    )
+    return {
+        "tls.crt": certificate.public_bytes(serialization.Encoding.PEM).decode(),
+        "tls.key": key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode(),
+    }
+
+
+class _SecretManager:
+    def __init__(self, value) -> None:
+        self.value = value
+        self.loaded: list[str] = []
+
+    def load_secret(self, name: str):
+        self.loaded.append(name)
+        return self.value
+
+
+class _SecretManagerService(AbstractSecretManagerService):
+    def __init__(self, uuid: str, manager: _SecretManager) -> None:
+        self.uuid = uuid
+        self.manager = manager
+        self.context = None
+
+    def get_secret_manager(self, infra):
+        self.context = infra
+        return self.manager
+
+
+class _Lookup:
+    def __init__(self, service) -> None:
+        self.service = service
+
+    def get_service_by_uuid(self, service_uuid: str):
+        return self.service if self.service.uuid == service_uuid else None
+
+    def get_service_by_name(self, service_name: str):
+        return None
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.files: dict[str, str] = {}
+        self.apply_result = "configured"
+        self.namespace_result = "namespace configured"
+        self.tls_result = "secret configured"
+
+    def _record(self, name, *args, **kwargs):
+        self.calls.append((name, args, kwargs))
+
+    def k8s_ensure_namespace(self, conn, namespace, **kwargs):
+        self._record("k8s_ensure_namespace", namespace, **kwargs)
+        return self.namespace_result
+
+    def k8s_apply_tls_secret(self, conn, name, **kwargs):
+        self._record("k8s_apply_tls_secret", name, **kwargs)
+        return self.tls_result
+
+    def fs_create_dir(self, conn, path):
+        self._record("fs_create_dir", path)
+
+    def fs_write_file(self, conn, path, content):
+        self._record("fs_write_file", path, content)
+        self.files[path] = content
+
+    def k8s_apply_manifest(self, conn, path, **kwargs):
+        self._record("k8s_apply_manifest", path, **kwargs)
+        return self.apply_result
+
+    def execute(self, conn, command, **kwargs):
+        self._record("execute", command, **kwargs)
+        if "rollout status" in command:
+            return "deployment successfully rolled out"
+        raise AssertionError(f"Unexpected command: {command}")
+
+
+@pytest.fixture
+def managed_gateway(tmp_path: Path):
+    serve_script = tmp_path / "serve.py"
+    serve_script.write_text("print('gateway')\n", encoding="utf-8")
+    tls = _tls_material()
+    manager = _SecretManager(tls)
+    manager_service = _SecretManagerService("manager-uuid", manager)
+    lookup = _Lookup(manager_service)
+    service = MLFlowGatewayManagedTlsK3sService(
+        name="MLflow Gateway TLS",
+        service_config_id="mlflow-gateway-3.8.1-k3s-managed-tls",
+        template="unused",
+        target_path="/tmp/mlflow-gateway-tls",
+        dockerfile="unused",
+        serve_script=str(serve_script),
+        start_script="unused",
+        port=30433,
+        tracking_uri="https://mlflow.example.test",
+        tracking_user="tracking-user",
+        tracking_pw="tracking-password",
+        requirements_txt="pydantic==2.0.0",
+        user="gateway-user",
+        pw="gateway-password",
+        tls_hostname="gateway.example.org",
+        tls_secret_manager_uuid="manager-uuid",
+        tls_secret_name="gateway-tls",
+    )
+    service.bind_service_lookup(lookup)
+    service.exec = _Executor()
+    return service, tls, manager, manager_service, lookup
+
+
+def test_renders_host_tls_ingress_without_pem(managed_gateway) -> None:
+    service, tls, _, _, _ = managed_gateway
+
+    manifest = service._render_gateway_manifest()
+    documents = list(yaml.safe_load_all(manifest))
+    ingress = next(item for item in documents if item.get("kind") == "Ingress")
+
+    assert len(documents) == 9
+    assert ingress["spec"]["rules"][0]["host"] == "gateway.example.org"
+    assert ingress["spec"]["tls"] == [
+        {
+            "hosts": ["gateway.example.org"],
+            "secretName": service.tls_kubernetes_secret_name,
+        }
+    ]
+    assert tls["tls.crt"] not in manifest
+    assert tls["tls.key"] not in manifest
+
+
+def test_setup_resolves_secret_through_bound_lookup_and_applies_tls_first(
+    managed_gateway,
+) -> None:
+    service, tls, manager, manager_service, lookup = managed_gateway
+
+    service.setup(SimpleNamespace(host="10.0.0.4"))
+
+    call_names = [call[0] for call in service.exec.calls]
+    assert call_names.index("k8s_ensure_namespace") < call_names.index(
+        "k8s_apply_tls_secret"
+    ) < call_names.index("k8s_apply_manifest")
+    tls_call = next(call for call in service.exec.calls if call[0] == "k8s_apply_tls_secret")
+    assert tls_call[2]["certificate"] == tls["tls.crt"]
+    assert tls_call[2]["private_key"] == tls["tls.key"]
+    assert manager.loaded == ["gateway-tls"]
+    assert manager_service.context is lookup
+    assert service.service_url == (
+        f"https://gateway.example.org{service.ingress_path}"
+    )
+    assert tls["tls.crt"] not in service.exec.files[service.manifest_path]
+    assert tls["tls.key"] not in service.exec.files[service.manifest_path]
+
+
+def test_validation_failure_happens_before_cluster_mutation(managed_gateway) -> None:
+    service, _, manager, _, _ = managed_gateway
+    manager.value = {"tls.crt": "not a certificate", "tls.key": "not a key"}
+
+    with pytest.raises(ValueError, match="valid PEM"):
+        service.setup(SimpleNamespace(host="10.0.0.4"))
+
+    assert service.exec.calls == []
+
+
+def test_missing_secret_manager_happens_before_cluster_mutation(
+    managed_gateway,
+) -> None:
+    service, _, _, _, _ = managed_gateway
+    service.tls_secret_manager_uuid = "missing-manager"
+
+    with pytest.raises(ValueError, match="not an available secret manager"):
+        service.setup(SimpleNamespace(host="10.0.0.4"))
+
+    assert service.exec.calls == []
+
+
+def test_rejects_mismatched_key_and_uncovered_hostname(managed_gateway) -> None:
+    service, tls, manager, _, _ = managed_gateway
+    manager.value = {**tls, "tls.key": _tls_material()["tls.key"]}
+    with pytest.raises(ValueError, match="do not match"):
+        service.setup(SimpleNamespace(host="10.0.0.4"))
+    assert service.exec.calls == []
+
+    manager.value = tls
+    service.tls_hostname = "other.example.org"
+    with pytest.raises(ValueError, match="does not cover"):
+        service.setup(SimpleNamespace(host="10.0.0.4"))
+    assert service.exec.calls == []
+
+
+def test_persistence_round_trip_contains_references_only(managed_gateway) -> None:
+    service, tls, _, _, _ = managed_gateway
+    service.exec = service.__dataclass_fields__["exec"].default_factory()
+
+    payload = dataclass_to_dict(service)
+    serialized = json.dumps(payload)
+    restored = dict_to_dataclass(payload)
+
+    assert isinstance(restored, MLFlowGatewayManagedTlsK3sService)
+    assert restored.tls_hostname == "gateway.example.org"
+    assert restored.tls_secret_manager_uuid == "manager-uuid"
+    assert restored.tls_secret_name == "gateway-tls"
+    assert tls["tls.crt"] not in serialized
+    assert tls["tls.key"] not in serialized
+
+
+def test_catalog_instantiates_managed_tls_variant() -> None:
+    configs = {config.id: config for config in load_all_service_configs()}
+    config = configs["mlflow-gateway-3.8.1-k3s-managed-tls"]
+    service = config.instantiate_service(
+        {
+            "${MLOX_STACKS_PATH}": str(Path(__file__).parents[3] / "mlox" / "services"),
+            "${MLOX_USER_HOME}": "/tmp/mlox",
+            "${MLOX_AUTO_PORT_REST}": "30433",
+            "${TRACKING_URI}": "https://mlflow.example",
+            "${TRACKING_USER}": "user",
+            "${TRACKING_PW}": "password",
+            "${GATEWAY_REQUIREMENTS_TXT}": "",
+            "${GATEWAY_CACHE_MAX_MODELS}": "10",
+            "${GATEWAY_CACHE_TTL_DAYS}": "10",
+            "${MLOX_AUTO_USER}": "gateway-user",
+            "${MLOX_AUTO_PW}": "gateway-password",
+            "${MODEL_REGISTRY_UUID}": "registry-uuid",
+            "${TLS_HOSTNAME}": "gateway.example.org",
+            "${TLS_SECRET_MANAGER_UUID}": "manager-uuid",
+            "${TLS_SECRET_NAME}": "gateway-tls",
+        }
+    )
+
+    assert isinstance(service, MLFlowGatewayManagedTlsK3sService)
+    assert service.tls_secret_manager_uuid == "manager-uuid"
+    assert service.tls_secret_name == "gateway-tls"

--- a/tests/unit/test_executors_kubernetes.py
+++ b/tests/unit/test_executors_kubernetes.py
@@ -14,9 +14,11 @@ class _Connection:
 class _Runner(KubernetesMixin):
     def __init__(self) -> None:
         self.commands: list[str] = []
+        self.options: list[dict] = []
 
     def _run_task(self, connection, *, command, **kwargs):
         self.commands.append(command)
+        self.options.append(kwargs)
         return "configured"
 
 
@@ -42,4 +44,6 @@ def test_apply_tls_secret_keeps_pem_out_of_command_history() -> None:
     assert certificate not in history
     assert private_key not in history
     assert "kubectl create secret tls gateway-tls" in history
+    assert runner.commands[-2].startswith("sh -c ")
+    assert runner.options[-2]["sudo"] is True
     assert runner.commands[-1].startswith("rm -f ")

--- a/tests/unit/test_executors_kubernetes.py
+++ b/tests/unit/test_executors_kubernetes.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from mlox.execution.kubernetes import KubernetesMixin
+
+
+class _Connection:
+    def __init__(self) -> None:
+        self.uploads: dict[str, bytes] = {}
+
+    def put(self, content, remote: str) -> None:
+        self.uploads[remote] = content.read()
+
+
+class _Runner(KubernetesMixin):
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    def _run_task(self, connection, *, command, **kwargs):
+        self.commands.append(command)
+        return "configured"
+
+
+def test_apply_tls_secret_keeps_pem_out_of_command_history() -> None:
+    connection = _Connection()
+    runner = _Runner()
+    certificate = "-----BEGIN CERTIFICATE-----\npublic\n-----END CERTIFICATE-----"
+    private_key = "-----BEGIN PRIVATE KEY-----\nprivate\n-----END PRIVATE KEY-----"
+
+    result = runner.k8s_apply_tls_secret(
+        connection,
+        "gateway-tls",
+        namespace="gateway",
+        certificate=certificate,
+        private_key=private_key,
+        kubeconfig="/etc/rancher/k3s/k3s.yaml",
+    )
+
+    assert result == "configured"
+    assert certificate.encode() in connection.uploads.values()
+    assert private_key.encode() in connection.uploads.values()
+    history = "\n".join(runner.commands)
+    assert certificate not in history
+    assert private_key not in history
+    assert "kubectl create secret tls gateway-tls" in history
+    assert runner.commands[-1].startswith("rm -f ")

--- a/tests/unit/test_registry_service.py
+++ b/tests/unit/test_registry_service.py
@@ -77,6 +77,7 @@ def test_mlflow_gateway_tui_settings_handlers_are_registered(monkeypatch):
     for config_id in (
         "mlflow-gateway-3.8.1-docker",
         "mlflow-gateway-3.8.1-k3s",
+        "mlflow-gateway-3.8.1-k3s-managed-tls",
     ):
         handler = get_handler(
             config_id=config_id,

--- a/tests/unit/test_service_runtime.py
+++ b/tests/unit/test_service_runtime.py
@@ -73,6 +73,33 @@ def _svc():
     return svc
 
 
+def test_get_dependent_service_can_require_type_and_capabilities():
+    service = _svc()
+    dependency = _svc()
+    dependency.capabilities = {ServiceCapability.SECRET_MANAGER, "web_ui"}
+    lookup = type(
+        "Lookup",
+        (),
+        {
+            "get_service_by_uuid": lambda self, uuid: dependency,
+            "get_service_by_name": lambda self, name: None,
+        },
+    )()
+    service.bind_service_lookup(lookup)
+
+    assert service.get_dependent_service(
+        dependency.uuid,
+        required_type=_Service,
+        required_capabilities={ServiceCapability.SECRET_MANAGER, "web_ui"},
+    ) is dependency
+    assert service.get_dependent_service(
+        dependency.uuid, required_type=_HealthService
+    ) is None
+    assert service.get_dependent_service(
+        dependency.uuid, required_capabilities={ServiceCapability.DATABASE}
+    ) is None
+
+
 def test_compose_up_restart_and_down_update_state():
     svc = _svc()
 

--- a/tests/unit/tui/test_service_setup_forms.py
+++ b/tests/unit/tui/test_service_setup_forms.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from mlox.service import ServiceCapability
+from mlox.service import AbstractSecretManagerService, ServiceCapability
 from mlox.tui.services import setup as service_setup
 
 
@@ -66,6 +66,61 @@ def test_mlflow_gateway_setup_spec_uses_registry_secrets() -> None:
     assert params["${TRACKING_PW}"] == "pw"
     assert params["${GATEWAY_REQUIREMENTS_TXT}"] == "numpy"
     assert params["${MODEL_REGISTRY_UUID}"] == "registry-1"
+
+
+def test_managed_tls_gateway_selects_secret_manager_reference() -> None:
+    class SecretManager:
+        def list_secrets(self, keys_only=False):
+            assert keys_only is True
+            return {"gateway-tls": None}
+
+    class SecretManagerService(AbstractSecretManagerService):
+        uuid = "manager-1"
+        name = "OpenBao"
+        capabilities = {ServiceCapability.SECRET_MANAGER}
+
+        def get_secret_manager(self, infra):
+            return SecretManager()
+
+    registry = SimpleNamespace(
+        uuid="registry-1",
+        name="MLflow",
+        capabilities={ServiceCapability.MODEL_REGISTRY},
+        get_secrets=lambda: {
+            "username": "mlflow",
+            "password": "pw",
+            "service_url": "https://mlflow.test",
+        },
+    )
+    manager_service = SecretManagerService()
+    services = [registry, manager_service]
+    infra = SimpleNamespace(
+        services=lambda: services,
+        get_service_by_uuid=lambda uuid: next(
+            (service for service in services if service.uuid == uuid), None
+        ),
+    )
+    spec = service_setup.mlflow_gateway_managed_tls(
+        infra, None, SimpleNamespace(name="Gateway TLS")
+    )
+    secret_field = next(field for field in spec.fields if field.name == "tls_secret_ref")
+
+    params = spec.params(
+        {
+            "registry_uuid": "registry-1",
+            "requirements_txt": "",
+            "cache_max_models": "10",
+            "cache_ttl_days": "10",
+            "tls_hostname": "gateway.example.org",
+            "tls_secret_ref": secret_field.options[0][1],
+        },
+        infra,
+    )
+
+    assert secret_field.options[0][0] == "OpenBao / gateway-tls"
+    assert params["${TLS_HOSTNAME}"] == "gateway.example.org"
+    assert params["${TLS_SECRET_MANAGER_UUID}"] == "manager-1"
+    assert params["${TLS_SECRET_NAME}"] == "gateway-tls"
 
 
 def test_gcp_setup_spec_exposes_missing_secret_manager_dependency() -> None:
@@ -134,6 +189,7 @@ def test_all_builtin_service_configs_have_tui_setup_handlers() -> None:
         "mlflow-3.8.1-docker",
         "mlflow-gateway-3.8.1-docker",
         "mlflow-gateway-3.8.1-k3s",
+        "mlflow-gateway-3.8.1-k3s-managed-tls",
         "mlflow-mlserver-2.22.0-docker",
         "mlflow-mlserver-3.8.1-docker",
         "mlflow-mlserver-3.8.1-k3s",

--- a/tests/unit/tui/test_service_setup_forms.py
+++ b/tests/unit/tui/test_service_setup_forms.py
@@ -111,14 +111,13 @@ def test_managed_tls_gateway_selects_secret_manager_reference() -> None:
             "requirements_txt": "",
             "cache_max_models": "10",
             "cache_ttl_days": "10",
-            "tls_hostname": "gateway.example.org",
             "tls_secret_ref": secret_field.options[0][1],
         },
         infra,
     )
 
     assert secret_field.options[0][0] == "OpenBao / gateway-tls"
-    assert params["${TLS_HOSTNAME}"] == "gateway.example.org"
+    assert all(field.name != "tls_hostname" for field in spec.fields)
     assert params["${TLS_SECRET_MANAGER_UUID}"] == "manager-1"
     assert params["${TLS_SECRET_NAME}"] == "gateway-tls"
 


### PR DESCRIPTION
## Summary

- add a distinct MLflow Gateway k3s variant that configures built-in Traefik with a user-provided TLS certificate
- persist only the secret-manager UUID and the certificate/private-key secret names
- resolve secret managers through abstract service lookup, without workspace or infrastructure references
- add GUI/TUI setup support and separate manifests/templates while leaving existing gateway variants unchanged
- minimize cluster impact by applying only the TLS Secret and dedicated gateway resources, with rollback-safe cleanup

## Testing

- `pytest` — 663 passed

Closes #89