### PR TITLE
fix: first Run 2026: test one MLOX install path and interface

### DIFF
--- a/mlox/logging_config.py
+++ b/mlox/logging_config.py
@@ -107,7 +107,7 @@ def configure_logging() -> None:
         logging.basicConfig(
             handlers=[TextualHandler(stderr=True, stdout=True)], level=logging.INFO
         )
-        logging.info("Textual logging configured")
+        logging.debug("Textual logging configured")
     elif os.environ.get("MLOX_TUI") == "true":
         logging.config.dictConfig(LOG_CONFIG)
         logging.warning(
@@ -115,4 +115,4 @@ def configure_logging() -> None:
         )
     else:
         logging.config.dictConfig(LOG_CONFIG)
-        logging.info("Logging configured")
+        logging.debug("Logging configured")

--- a/tests/unit/tui/test_overview_panel.py
+++ b/tests/unit/tui/test_overview_panel.py
@@ -16,7 +16,7 @@ from mlox.tui.screens.dashboard.overview_panel import OverviewPanel
 
 
 def _render_panel(renderable) -> str:
-    console = Console(file=io.StringIO(), record=True, width=120)
+    console = Console(file=io.StringIO(), record=True, width=120, height=40)
     console.print(renderable)
     return console.export_text()
 

--- a/tests/unit/tui/test_server_actions.py
+++ b/tests/unit/tui/test_server_actions.py
@@ -46,7 +46,7 @@ class DashboardServerInfoTestApp(App):
 def _render_text(renderable: object) -> str:
     if isinstance(renderable, str):
         return renderable
-    console = Console(file=io.StringIO(), record=True, width=140)
+    console = Console(file=io.StringIO(), record=True, width=140, height=40)
     console.print(renderable)
     return console.export_text()
 


### PR DESCRIPTION
Refs #81

Fixed first-run CLI noise by downgrading MLOX logging startup messages from INFO to DEBUG, and fixed TUI unit test Rich Console setup to pass explicit height so wide table assertions render correctly.

Could not run the suite locally: __. Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.